### PR TITLE
fix: reconcile renamed and removed modules

### DIFF
--- a/packages/core/src/planner.ts
+++ b/packages/core/src/planner.ts
@@ -601,12 +601,10 @@ export class Planner extends Effect.Service<Planner>()("Planner", {
 			const claimedRoots = new Set<string>();
 			for (const module of byRoot.values()) {
 				if (claimedRoots.has(module.root))
-					return yield* Effect.fail(
-						new PlannerError({
-							path: module.root,
-							message: "Module Root Conflict",
-						}),
-					);
+					return yield* new PlannerError({
+						path: module.root,
+						message: "Module Root Conflict",
+					});
 
 				claimedRoots.add(module.root);
 			}

--- a/packages/core/src/planner.ts
+++ b/packages/core/src/planner.ts
@@ -13,6 +13,7 @@ import {
 	ConfigStore,
 	type DiscoveredModule,
 	type ModuleId,
+	type Slots,
 } from "./config";
 import { dependencyFormatFor } from "./environment";
 import { AggregateConflictError, GeneratorError, PlannerError } from "./errors";
@@ -96,6 +97,49 @@ function templateMatchesId(templateId: string, moduleTemplateId: string) {
 	);
 }
 
+function sameModuleIdentity(
+	config: Config,
+	ensured: EnsureModuleContribution["module"],
+) {
+	if (
+		config.template.id !== ensured.template.id ||
+		config.template.version !== ensured.template.version
+	)
+		return false;
+
+	if (config.type === "app" && ensured.type === "app")
+		return config.framework === ensured.framework;
+
+	if (config.type === "package" && ensured.type === "package")
+		return config.packageType === ensured.packageType;
+
+	return false;
+}
+
+function findAdoptableModule(
+	modules: Iterable<ManagedModuleRecord>,
+	ensuredIds: ReadonlySet<ModuleId>,
+	staticRoots: ReadonlySet<string>,
+	contribution: EnsureModuleContribution,
+	definitionId: string,
+) {
+	const candidates = [...modules].filter(
+		(module) =>
+			!ensuredIds.has(module.id) &&
+			!staticRoots.has(module.root) &&
+			module.definitionIds.includes(definitionId) &&
+			sameModuleIdentity(module.config, contribution.module),
+	);
+
+	return candidates.length === 1 ? candidates[0] : undefined;
+}
+
+function rebaseSlots(ensured: Slots, onDisk: Slots): Slots {
+	return Object.fromEntries(
+		Object.entries(ensured).map(([slot, path]) => [slot, onDisk[slot] ?? path]),
+	);
+}
+
 function cloneModule(
 	module: DiscoveredModule,
 	record?: ModuleRecord,
@@ -129,6 +173,8 @@ function mergeEnsuredModule(
 	ensured: EnsureModuleContribution,
 	moduleId: ModuleId,
 	definitionId: string,
+	alreadyEnsured: boolean,
+	onDiskSlots: Slots,
 ): Effect.Effect<ManagedModuleRecord, PlannerError> {
 	const nextConfig = ensured.module;
 
@@ -165,10 +211,17 @@ function mergeEnsuredModule(
 			config: {
 				...nextConfig,
 				id: existing.id,
-				slots: { ...nextConfig.slots, ...existing.config.slots },
+				slots: alreadyEnsured
+					? {
+							...rebaseSlots(nextConfig.slots, onDiskSlots),
+							...existing.config.slots,
+						}
+					: rebaseSlots(nextConfig.slots, onDiskSlots),
 				type: "app",
 			},
-			definitionIds: [...new Set([...existing.definitionIds, definitionId])],
+			definitionIds: alreadyEnsured
+				? [...new Set([...existing.definitionIds, definitionId])]
+				: [definitionId],
 			id: existing.id,
 			root: existing.root,
 		});
@@ -190,17 +243,26 @@ function mergeEnsuredModule(
 		return Effect.succeed({
 			config: {
 				...nextConfig,
-				capabilities: [
-					...new Set([
-						...(nextConfig.capabilities ?? []),
-						...(existing.config.capabilities ?? []),
-					]),
-				],
+				capabilities: alreadyEnsured
+					? [
+							...new Set([
+								...(nextConfig.capabilities ?? []),
+								...(existing.config.capabilities ?? []),
+							]),
+						]
+					: [...(nextConfig.capabilities ?? [])],
 				id: existing.id,
-				slots: { ...nextConfig.slots, ...existing.config.slots },
+				slots: alreadyEnsured
+					? {
+							...rebaseSlots(nextConfig.slots, onDiskSlots),
+							...existing.config.slots,
+						}
+					: rebaseSlots(nextConfig.slots, onDiskSlots),
 				type: "package",
 			},
-			definitionIds: [...new Set([...existing.definitionIds, definitionId])],
+			definitionIds: alreadyEnsured
+				? [...new Set([...existing.definitionIds, definitionId])]
+				: [definitionId],
 			id: existing.id,
 			root: existing.root,
 		});
@@ -485,11 +547,35 @@ export class Planner extends Effect.Service<Planner>()("Planner", {
 			);
 			const byKey = new Map<string, ModuleId>();
 			const usedIds = new Set(discovered.map((module) => module.id));
+			const ensuredIds = new Set<ModuleId>();
+			const onDiskSlots = new Map<ModuleId, Slots>(
+				discovered.map((module) => [module.id, module.slots]),
+			);
+
+			const staticRoots = new Set(
+				evaluated.flatMap((entry) =>
+					entry.contributions.flatMap((contribution) =>
+						contribution._tag === "EnsureModuleContribution"
+							? [contribution.root]
+							: [],
+					),
+				),
+			);
 
 			for (const entry of evaluated)
 				for (const contribution of entry.contributions)
 					if (contribution._tag === "EnsureModuleContribution") {
-						const existing = byRoot.get(contribution.root);
+						const direct = byRoot.get(contribution.root);
+						const existing =
+							direct ??
+							findAdoptableModule(
+								byRoot.values(),
+								ensuredIds,
+								staticRoots,
+								contribution,
+								entry.definition.id,
+							);
+
 						const moduleId = existing
 							? existing.id
 							: yield* configStore.generateId(usedIds);
@@ -500,10 +586,30 @@ export class Planner extends Effect.Service<Planner>()("Planner", {
 							contribution,
 							moduleId,
 							entry.definition.id,
+							ensuredIds.has(moduleId),
+							onDiskSlots.get(moduleId) ?? {},
 						);
+
+						if (existing && !direct) byRoot.delete(existing.root);
+
 						byRoot.set(contribution.root, merged);
 						byKey.set(contribution.moduleKey, merged.id);
+
+						ensuredIds.add(merged.id);
 					}
+
+			const claimedRoots = new Set<string>();
+			for (const module of byRoot.values()) {
+				if (claimedRoots.has(module.root))
+					return yield* Effect.fail(
+						new PlannerError({
+							path: module.root,
+							message: "Module Root Conflict",
+						}),
+					);
+
+				claimedRoots.add(module.root);
+			}
 
 			return {
 				modules: [...byRoot.values()],

--- a/packages/core/tests/planner.test.ts
+++ b/packages/core/tests/planner.test.ts
@@ -34,7 +34,9 @@ import {
 import { readJson, withTempDir, writeJson } from "./harness";
 
 interface TestConfig extends Record<string, unknown> {
+	readonly audit?: boolean;
 	readonly auth?: boolean;
+	readonly dual?: boolean;
 	readonly kit?: boolean;
 	readonly logs?: boolean;
 	readonly metrics?: boolean;

--- a/packages/core/tests/planner.test.ts
+++ b/packages/core/tests/planner.test.ts
@@ -1,3 +1,5 @@
+import { rename, rm } from "node:fs/promises";
+import { join } from "node:path";
 import { NodeContext } from "@effect/platform-node";
 import { Cause, Effect, Exit, Layer, Option, Schema } from "effect";
 import { describe, expect, it } from "vitest";
@@ -269,6 +271,83 @@ function sharedModuleRegistry() {
 		addons: [
 			telemetryAddon("logs", "client"),
 			telemetryAddon("metrics", "provider"),
+		],
+	});
+}
+
+function ownershipRegistry() {
+	const kitAddon = (id: "logs" | "audit", root: string) =>
+		defineAddon<TestConfig>({
+			id,
+			name: id === "logs" ? "Logs" : "Audit",
+			version: "0.1.0",
+			category: "tooling",
+			exclusive: false,
+			targetMode: "single",
+			when: (config) => config[id] === true,
+			contribute: () => [
+				ensurePackageModule(id, root, {
+					packageType: "library",
+					template: { id: "kit", version: 1 },
+					capabilities: [id],
+					slots: {},
+				}),
+				leafTextFile(
+					ensuredModuleTarget(id),
+					`src/${id}.ts`,
+					`export const ${id} = true;\n`,
+				),
+			],
+		});
+
+	return defineRegistry({
+		frameworks: [],
+		templates: [],
+		addons: [
+			kitAddon("logs", "packages/telemetry"),
+			kitAddon("audit", "packages/audit"),
+		],
+	});
+}
+
+function siblingRegistry() {
+	return defineRegistry({
+		frameworks: [],
+		templates: [],
+		addons: [
+			defineAddon<TestConfig>({
+				id: "dual",
+				name: "Dual",
+				version: "0.1.0",
+				category: "tooling",
+				exclusive: false,
+				targetMode: "single",
+				when: (config) => config.dual === true,
+				contribute: () => [
+					ensurePackageModule("one", "packages/one", {
+						packageType: "library",
+						template: { id: "kit", version: 1 },
+						capabilities: [],
+						slots: {},
+					}),
+					leafTextFile(
+						ensuredModuleTarget("one"),
+						"src/one.ts",
+						"export const one = true;\n",
+					),
+					ensurePackageModule("two", "packages/two", {
+						packageType: "library",
+						template: { id: "kit", version: 1 },
+						capabilities: [],
+						slots: {},
+					}),
+					leafTextFile(
+						ensuredModuleTarget("two"),
+						"src/two.ts",
+						"export const two = true;\n",
+					),
+				],
+			}),
 		],
 	});
 }
@@ -582,6 +661,9 @@ describe("planner", () => {
 			);
 
 			expect(removalPlan.manifest.modules[telemetryId]).toBeDefined();
+			expect(removalPlan.manifest.modules[telemetryId]?.definitionIds).toEqual([
+				"logs",
+			]);
 			expect(removalPlan.removals).toEqual([
 				"packages/telemetry/src/metrics.ts",
 			]);
@@ -600,9 +682,303 @@ describe("planner", () => {
 
 			const survivorConfig = decodePackageConfig(survivorForge.content);
 
-			expect([...survivorConfig.capabilities].sort()).toEqual([
-				"logs",
-				"metrics",
+			expect([...survivorConfig.capabilities]).toEqual(["logs"]);
+			expect(survivorConfig.slots).toEqual({ client: "src/client.ts" });
+		});
+	});
+
+	it("adopts a renamed module root instead of recreating it", async () => {
+		await withTempDir("planner-renamed-root", async (directory) => {
+			const registry = sharedModuleRegistry();
+			const installs: InstallRecord[] = [
+				{ definitionId: "logs", targets: [{ kind: "project" }] },
+			];
+
+			const createPlan = await Effect.runPromise(
+				planCreateEffect(directory, { logs: true }, registry),
+			);
+
+			await Effect.runPromise(applyPlanEffect(directory, createPlan));
+
+			const telemetryId = moduleIdByRoot(
+				createPlan.manifest.modules,
+				"packages/telemetry",
+			);
+
+			expect(telemetryId).toBeDefined();
+			if (!telemetryId) throw new Error("Missing Telemetry Module");
+
+			await rename(
+				join(directory, "packages/telemetry"),
+				join(directory, "packages/observability"),
+			);
+
+			const updatePlan = await Effect.runPromise(
+				planInstalledEffect(directory, { logs: true }, installs, registry),
+			);
+
+			expect(Object.keys(updatePlan.manifest.modules)).toEqual([telemetryId]);
+			expect(updatePlan.manifest.modules[telemetryId]?.root).toBe(
+				"packages/observability",
+			);
+			expect(
+				updatePlan.writes.some(
+					(write) => write.path === "packages/observability/forge.json",
+				),
+			).toBe(true);
+			expect(
+				updatePlan.writes.some(
+					(write) => write.path === "packages/observability/src/logs.ts",
+				),
+			).toBe(true);
+			expect(
+				updatePlan.writes.some((write) =>
+					write.path.startsWith("packages/telemetry/"),
+				),
+			).toBe(false);
+		});
+	});
+
+	it("adopts a renamed app module root", async () => {
+		await withTempDir("planner-renamed-app", async (directory) => {
+			const registry = testRegistry();
+
+			const createPlan = await Effect.runPromise(
+				planCreateEffect(directory, { web: "nextjs" }, registry),
+			);
+
+			await Effect.runPromise(applyPlanEffect(directory, createPlan));
+
+			const webId = moduleIdByRoot(createPlan.manifest.modules, "apps/web");
+
+			expect(webId).toBeDefined();
+			if (!webId) throw new Error("Missing Web Module");
+
+			await rename(join(directory, "apps/web"), join(directory, "apps/site"));
+
+			const updatePlan = await Effect.runPromise(
+				planInstalledEffect(directory, { web: "nextjs" }, [], registry),
+			);
+
+			expect(Object.keys(updatePlan.manifest.modules)).toEqual([webId]);
+			expect(updatePlan.manifest.modules[webId]?.root).toBe("apps/site");
+			expect(
+				updatePlan.writes.some(
+					(write) => write.path === "apps/site/app/layout.tsx",
+				),
+			).toBe(true);
+			expect(
+				updatePlan.writes.some((write) => write.path.startsWith("apps/web/")),
+			).toBe(false);
+		});
+	});
+
+	it("preserves a moved slot path through replanning", async () => {
+		await withTempDir("planner-moved-slot", async (directory) => {
+			const registry = sharedModuleRegistry();
+			const installs: InstallRecord[] = [
+				{ definitionId: "logs", targets: [{ kind: "project" }] },
+			];
+
+			const createPlan = await Effect.runPromise(
+				planCreateEffect(directory, { logs: true }, registry),
+			);
+
+			await Effect.runPromise(applyPlanEffect(directory, createPlan));
+
+			const configPath = join(directory, "packages/telemetry/forge.json");
+			const onDisk = await readJson<{ slots: Record<string, string> }>(
+				configPath,
+			);
+
+			await writeJson(configPath, {
+				...onDisk,
+				slots: { ...onDisk.slots, client: "src/moved/client.ts" },
+			});
+
+			const updatePlan = await Effect.runPromise(
+				planInstalledEffect(directory, { logs: true }, installs, registry),
+			);
+
+			const forgeWrite = updatePlan.writes.find(
+				(write) => write.path === "packages/telemetry/forge.json",
+			);
+
+			expect(forgeWrite).toBeDefined();
+			if (!forgeWrite) throw new Error("Missing Telemetry Config Write");
+
+			expect(decodePackageConfig(forgeWrite.content).slots).toEqual({
+				client: "src/moved/client.ts",
+			});
+		});
+	});
+
+	it("keeps moved slot paths for every ensure of a shared module", async () => {
+		await withTempDir("planner-shared-moved-slot", async (directory) => {
+			const registry = sharedModuleRegistry();
+			const installs: InstallRecord[] = [
+				{ definitionId: "logs", targets: [{ kind: "project" }] },
+				{ definitionId: "metrics", targets: [{ kind: "project" }] },
+			];
+
+			const createPlan = await Effect.runPromise(
+				planCreateEffect(directory, { logs: true, metrics: true }, registry),
+			);
+
+			await Effect.runPromise(applyPlanEffect(directory, createPlan));
+
+			const configPath = join(directory, "packages/telemetry/forge.json");
+			const onDisk = await readJson<{ slots: Record<string, string> }>(
+				configPath,
+			);
+
+			await writeJson(configPath, {
+				...onDisk,
+				slots: { ...onDisk.slots, provider: "src/custom/provider.ts" },
+			});
+
+			const updatePlan = await Effect.runPromise(
+				planInstalledEffect(
+					directory,
+					{ logs: true, metrics: true },
+					installs,
+					registry,
+				),
+			);
+
+			const forgeWrite = updatePlan.writes.find(
+				(write) => write.path === "packages/telemetry/forge.json",
+			);
+
+			expect(forgeWrite).toBeDefined();
+			if (!forgeWrite) throw new Error("Missing Telemetry Config Write");
+
+			expect(decodePackageConfig(forgeWrite.content).slots).toEqual({
+				client: "src/client.ts",
+				provider: "src/custom/provider.ts",
+			});
+		});
+	});
+
+	it("leaves renamed modules owned by other definitions alone", async () => {
+		await withTempDir("planner-adoption-ownership", async (directory) => {
+			const registry = ownershipRegistry();
+
+			const createPlan = await Effect.runPromise(
+				planCreateEffect(directory, { audit: true }, registry),
+			);
+
+			await Effect.runPromise(applyPlanEffect(directory, createPlan));
+
+			const auditId = moduleIdByRoot(
+				createPlan.manifest.modules,
+				"packages/audit",
+			);
+
+			expect(auditId).toBeDefined();
+			if (!auditId) throw new Error("Missing Audit Module");
+
+			await rename(
+				join(directory, "packages/audit"),
+				join(directory, "packages/audit-renamed"),
+			);
+
+			const updatePlan = await Effect.runPromise(
+				planInstalledEffect(
+					directory,
+					{ audit: true, logs: true },
+					[
+						{ definitionId: "logs", targets: [{ kind: "project" }] },
+						{ definitionId: "audit", targets: [{ kind: "project" }] },
+					],
+					registry,
+				),
+			);
+
+			const roots = Object.values(updatePlan.manifest.modules)
+				.map((record) => record.root)
+				.sort();
+
+			expect(roots).toEqual(["packages/audit-renamed", "packages/telemetry"]);
+			expect(updatePlan.manifest.modules[auditId]?.root).toBe(
+				"packages/audit-renamed",
+			);
+			expect(updatePlan.manifest.modules[auditId]?.definitionIds).toEqual([
+				"audit",
+			]);
+		});
+	});
+
+	it("heals a deleted sibling module without stealing the survivor", async () => {
+		await withTempDir("planner-sibling-heal", async (directory) => {
+			const registry = siblingRegistry();
+			const installs: InstallRecord[] = [
+				{ definitionId: "dual", targets: [{ kind: "project" }] },
+			];
+
+			const createPlan = await Effect.runPromise(
+				planCreateEffect(directory, { dual: true }, registry),
+			);
+
+			await Effect.runPromise(applyPlanEffect(directory, createPlan));
+
+			await rm(join(directory, "packages/one"), {
+				force: true,
+				recursive: true,
+			});
+
+			const updatePlan = await Effect.runPromise(
+				planInstalledEffect(directory, { dual: true }, installs, registry),
+			);
+
+			const roots = Object.values(updatePlan.manifest.modules)
+				.map((record) => record.root)
+				.sort();
+
+			expect(roots).toEqual(["packages/one", "packages/two"]);
+			expect(
+				updatePlan.writes.some(
+					(write) => write.path === "packages/one/src/one.ts",
+				),
+			).toBe(true);
+		});
+	});
+
+	it("falls back to fresh modules when adoption is ambiguous", async () => {
+		await withTempDir("planner-ambiguous-adoption", async (directory) => {
+			const registry = siblingRegistry();
+			const installs: InstallRecord[] = [
+				{ definitionId: "dual", targets: [{ kind: "project" }] },
+			];
+
+			const createPlan = await Effect.runPromise(
+				planCreateEffect(directory, { dual: true }, registry),
+			);
+
+			await Effect.runPromise(applyPlanEffect(directory, createPlan));
+
+			await rename(
+				join(directory, "packages/one"),
+				join(directory, "packages/one-moved"),
+			);
+			await rename(
+				join(directory, "packages/two"),
+				join(directory, "packages/two-moved"),
+			);
+
+			const updatePlan = await Effect.runPromise(
+				planInstalledEffect(directory, { dual: true }, installs, registry),
+			);
+
+			const roots = Object.values(updatePlan.manifest.modules)
+				.map((record) => record.root)
+				.sort();
+
+			expect(roots).toEqual([
+				"packages/one",
+				"packages/one-moved",
+				"packages/two",
+				"packages/two-moved",
 			]);
 		});
 	});

--- a/tests/scenarios/src/scenarios/add.test.ts
+++ b/tests/scenarios/src/scenarios/add.test.ts
@@ -159,7 +159,11 @@ describe("add", () => {
 			const uiConfigAfter = await readJson<UiModuleConfig>(uiConfigPath);
 			const uiPackageAfter = await readJson<UiPackageJson>(uiPackageJsonPath);
 
-			expect(uiConfigAfter.capabilities).toContain("tailwind");
+			expect([...uiConfigAfter.capabilities].sort()).toEqual([
+				"react",
+				"tailwind",
+				"ui",
+			]);
 			expect(uiPackageAfter.devDependencies?.tailwindcss).toBe("catalog:");
 			expect(uiPackageAfter.devDependencies?.["@tailwindcss/postcss"]).toBe(
 				"catalog:",
@@ -327,7 +331,11 @@ describe("add", () => {
 				join(workspace.projectRoot, "packages/ui/package.json"),
 			);
 
-			expect(uiConfig.capabilities).toContain("tailwind");
+			expect([...uiConfig.capabilities].sort()).toEqual([
+				"react",
+				"tailwind",
+				"ui",
+			]);
 			expect(uiPackageJson.devDependencies?.tailwindcss).toBe("catalog:");
 		});
 	}, 240_000);

--- a/tests/scenarios/src/scenarios/modules.test.ts
+++ b/tests/scenarios/src/scenarios/modules.test.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	createProject,
+	pathExists,
 	readJson,
 	renameModuleRoot,
 	updateProject,
@@ -41,6 +42,15 @@ describe("module identity", () => {
 			expect(manifest.modules[beforeRename.id]?.root).toBe(
 				"packages/design-system",
 			);
+			expect(await pathExists(join(workspace.projectRoot, "packages/ui"))).toBe(
+				false,
+			);
+			expect(Object.keys(manifest.modules)).toHaveLength(2);
+			expect(
+				Object.values(manifest.modules).some(
+					(record) => record.root === "packages/ui",
+				),
+			).toBe(false);
 		});
 	});
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR teaches the planner how to reconcile modules whose directory has been renamed or removed since the last plan, instead of blindly recreating them at the canonical root. It introduces module adoption (`findAdoptableModule`, `sameModuleIdentity`) and slot-rebasing (`rebaseSlots`) so on-disk customisations survive replanning.

- **`planner.ts`**: adds `findAdoptableModule` / `sameModuleIdentity` / `rebaseSlots` helpers; threads `alreadyEnsured` and `onDiskSlots` through `mergeEnsuredModule`; builds a `staticRoots` guard to prevent cross-ownership adoption; and adds a post-loop `claimedRoots` check that errors cleanly if two entries end up claiming the same on-disk root.
- **`planner.test.ts`**: eight new integration tests covering single rename, app rename, slot preservation across replanning, ownership isolation, sibling-heal, and ambiguous-adoption fallback; `ownershipRegistry` and `siblingRegistry` helper factories are added.
- **`add.test.ts` / `modules.test.ts`**: assertions tightened to reflect the corrected capability-merge behaviour and to verify no ghost entry for the old path remains in the manifest.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the adoption logic is well-guarded and the new tests cover the main edge cases thoroughly.

The adoption heuristic is carefully bounded — staticRoots prevents cross-definition stealing, ensuredIds prevents double-adoption, and the claimedRoots guard catches any collision that slips through. The one minor gap is that TestConfig in the test file does not explicitly declare dual and audit, relying on the Record index signature.

packages/core/src/planner.ts is the only file with meaningful logic complexity — specifically the collectModules loop where byRoot is keyed by contribution root but module records carry the on-disk root.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/planner.ts | Core logic change: adds module-adoption heuristic (findAdoptableModule, sameModuleIdentity, rebaseSlots) and alreadyEnsured / onDiskSlots params to mergeEnsuredModule; also adds a post-loop claimedRoots duplicate-root guard. |
| packages/core/tests/planner.test.ts | Adds ownershipRegistry/siblingRegistry helpers and eight new integration test cases covering renames, slot rebasing, ownership isolation, sibling-heal, and ambiguous-adoption fallback; also tightens an existing shared-module assertion. |
| tests/scenarios/src/scenarios/add.test.ts | Tightens two capability assertions from toContain to an exact sorted array, reflecting the new behaviour where only the correct owning definition capabilities are merged. |
| tests/scenarios/src/scenarios/modules.test.ts | Adds three extra assertions after a module-root rename: the old directory no longer exists, the manifest has exactly 2 modules, and none of them points to the old path. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[EnsureModuleContribution] --> B{byRoot.get contribution.root?}
    B -- direct hit --> C[existing = direct]
    B -- miss --> D[findAdoptableModule]
    D --> E{candidates.length == 1?}
    E -- yes --> F[existing = candidate adopted module]
    E -- no or zero --> G[existing = undefined]
    C --> H[moduleId = existing.id]
    F --> H
    G --> I[generateId new moduleId]
    H --> J[mergeEnsuredModule alreadyEnsured and onDiskSlots]
    I --> J
    J --> K{adopted? existing and not direct}
    K -- yes --> L[byRoot.delete existing.root then byRoot.set contribution.root merged]
    K -- no --> M[byRoot.set contribution.root merged]
    L --> N[ensuredIds.add merged.id]
    M --> N
    N --> O[post-loop claimedRoots duplicate-root guard]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/tests/planner.test.ts`, line 36-46 ([link](https://github.com/ryuudotgg/forge/blob/6a23e68e04120a98be6d2ea2a8b8b2e74c1b977d/packages/core/tests/planner.test.ts#L36-L46)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `TestConfig` is missing `dual` and `audit` fields used by the new registries. `config.dual` and `config["audit"]` are resolved through the `Record<string, unknown>` index signature, so they return `unknown` instead of a concrete type. If those fields are ever added with a different type in the future, the compiler won't catch the inconsistency in the registries. Adding them as `readonly audit?: boolean; readonly dual?: boolean;` would make the intent explicit and keep the interface consistent with the other flag fields.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/core/tests/planner.test.ts
   Line: 36-46

   Comment:
   `TestConfig` is missing `dual` and `audit` fields used by the new registries. `config.dual` and `config["audit"]` are resolved through the `Record<string, unknown>` index signature, so they return `unknown` instead of a concrete type. If those fields are ever added with a different type in the future, the compiler won't catch the inconsistency in the registries. Adding them as `readonly audit?: boolean; readonly dual?: boolean;` would make the intent explicit and keep the interface consistent with the other flag fields.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/core/tests/planner.test.ts:36-46
`TestConfig` is missing `dual` and `audit` fields used by the new registries. `config.dual` and `config["audit"]` are resolved through the `Record<string, unknown>` index signature, so they return `unknown` instead of a concrete type. If those fields are ever added with a different type in the future, the compiler won't catch the inconsistency in the registries. Adding them as `readonly audit?: boolean; readonly dual?: boolean;` would make the intent explicit and keep the interface consistent with the other flag fields.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: reconcile renamed and removed modul..."](https://github.com/ryuudotgg/forge/commit/6a23e68e04120a98be6d2ea2a8b8b2e74c1b977d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37135428)</sub>

<!-- /greptile_comment -->