### PR TITLE
fix: trim names before deriving slugs

### DIFF
--- a/packages/cli/src/steps/project/name.ts
+++ b/packages/cli/src/steps/project/name.ts
@@ -78,7 +78,8 @@ const nameStep = defineStep<{ name: string; slug: string }>({
 
 		if (isCancel(name)) cancel();
 
-		return { name, slug: slugify(name) };
+		const trimmed = name.trim();
+		return { name: trimmed, slug: slugify(trimmed) };
 	},
 });
 

--- a/packages/cli/src/utils/slugify.ts
+++ b/packages/cli/src/utils/slugify.ts
@@ -1,8 +1,9 @@
 export function slugify(input: string): string {
 	return input
+		.trim()
 		.toLowerCase()
 		.replace(/[^\w\s-]/g, "")
 		.replace(/[\s_]+/g, "-")
 		.replace(/-+/g, "-")
-		.trim();
+		.replace(/^-+|-+$/g, "");
 }

--- a/packages/cli/tests/steps-project.test.ts
+++ b/packages/cli/tests/steps-project.test.ts
@@ -177,6 +177,15 @@ describe("project steps", () => {
 			expect(validate?.("!!!")).toBe("We couldn't generate a slug.");
 			expect(validate?.("Acme")).toBeUndefined();
 		});
+
+		it("trims prompted names before deriving the slug", async () => {
+			promptMocks.text.mockResolvedValue("  Acme  ");
+
+			await expect(nameStep.execute({}, true)).resolves.toEqual({
+				name: "Acme",
+				slug: "acme",
+			});
+		});
 	});
 
 	describe("path", () => {

--- a/packages/cli/tests/utils.test.ts
+++ b/packages/cli/tests/utils.test.ts
@@ -34,6 +34,15 @@ describe("slugify", () => {
 	it("collapses repeated dashes", () => {
 		expect(slugify("a--b")).toBe("a-b");
 	});
+
+	it("trims surrounding whitespace before dashing", () => {
+		expect(slugify("  Acme  ")).toBe("acme");
+	});
+
+	it("strips leading and trailing dashes", () => {
+		expect(slugify("-acme-")).toBe("acme");
+		expect(slugify("__Acme__")).toBe("acme");
+	});
 });
 
 describe("cancel", () => {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related bugs: `slugify` was calling `.trim()` at the end of the pipeline where it was effectively a no-op (whitespace had already been converted to dashes), and the prompt result in `name.ts` was not trimmed before being stored or slugified.

- **`slugify.ts`**: `.trim()` is moved to the top of the chain so whitespace is removed before any transformations, and the trailing `.trim()` is replaced with `.replace(/^-+|-+$/g, "")` to strip leading/trailing dashes that result from converting surrounding spaces or underscores.
- **`name.ts`**: The raw string returned by the `text()` prompt is now explicitly trimmed before being stored as `name` and passed to `slugify`, matching what `Schema.Trim` was already doing inside the validator.
- Both fixes are covered by new unit and integration tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are small, targeted, and fully covered by new tests.

Both fixes are correct: moving `.trim()` to the top of the `slugify` chain and replacing the inert trailing `.trim()` with a dash-stripping regex closes the actual gap, and the explicit `name.trim()` in the prompt path aligns the stored value with what the schema validator was already computing. The new tests directly exercise the fixed paths. No regressions introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/slugify.ts | Moves `.trim()` to the start of the chain and replaces the trailing `.trim()` with `.replace(/^-+|-+$/g, "")` to correctly strip leading/trailing dashes that were produced by converting surrounding whitespace or underscores. |
| packages/cli/src/steps/project/name.ts | Trims the raw prompt result before storing `name` and deriving the slug, aligning the returned value with what the validator already computed via `Schema.Trim`. |
| packages/cli/tests/utils.test.ts | Adds two new `slugify` test cases: surrounding whitespace trimming and leading/trailing dash stripping. |
| packages/cli/tests/steps-project.test.ts | Adds an integration test confirming that a padded name is trimmed before the step returns its result. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User input\n(e.g. '  Acme  ')"] --> B["text() prompt\nvalidate callback"]
    B --> C["Schema.Trim decodes value\n→ 'Acme'"]
    C --> D["slugify('Acme') validated\nagainst slugSchema"]
    D -->|valid| E["Prompt resolves\nraw string '  Acme  '"]
    D -->|invalid| F["Error message shown\nto user"]
    E --> G["name.trim()\n→ 'Acme'"]
    G --> H["slugify(trimmed)"]
    H --> I[".trim() at start\n→ 'Acme'"]
    I --> J[".toLowerCase()\n→ 'acme'"]
    J --> K[".replace non-word/space/dash\n→ 'acme'"]
    K --> L[".replace spaces+underscores\n→ 'acme'"]
    L --> M[".replace repeated dashes\n→ 'acme'"]
    M --> N[".replace leading/trailing dashes\n→ 'acme'"]
    N --> O["Return { name: 'Acme', slug: 'acme' }"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: trim names before deriving slugs"](https://github.com/ryuudotgg/forge/commit/d6069e536ad6ad3f04874885fc2987894af60050) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37157758)</sub>

<!-- /greptile_comment -->