### PR TITLE
feat: mark roadmap choices as coming soon

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -7,7 +7,7 @@ import { orchestrate } from "../orchestrator";
 import { presets } from "../presets";
 import { steps } from "../steps";
 import type { PartialConfig } from "../steps/types";
-import { listOr } from "./shared";
+import { listOr } from "../utils/list";
 
 export async function runCreate(
 	values: Record<string, string | boolean | undefined>,

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -9,8 +9,8 @@ import {
 	RegistryLoadError,
 } from "@ryuujs/generators";
 import { cancel } from "../utils/cancel";
+import { listAnd } from "../utils/list";
 import { applyInstalledPlan, loadManagedProject } from "./lifecycle";
-import { listAnd } from "./shared";
 
 function moduleLabel(
 	moduleId: string,

--- a/packages/cli/src/steps/auth/provider.ts
+++ b/packages/cli/src/steps/auth/provider.ts
@@ -5,7 +5,7 @@ import { cancel } from "../../utils/cancel";
 import {
 	availableChoice,
 	choiceOptions,
-	unavailableMessage,
+	unsupportedMessage,
 } from "../../utils/choices";
 import { defineStep, SKIP } from "../types";
 
@@ -53,7 +53,7 @@ const authenticationStep = defineStep<typeof authenticationSchema.Type>({
 			if (authenticationProviders.available(authentication))
 				return authentication;
 
-			log.warn(unavailableMessage(authenticationProviders, authentication));
+			log.warn(unsupportedMessage(authenticationProviders, [authentication]));
 		}
 	},
 });

--- a/packages/cli/src/steps/auth/provider.ts
+++ b/packages/cli/src/steps/auth/provider.ts
@@ -1,12 +1,17 @@
-import { isCancel, select } from "@clack/prompts";
+import { isCancel, log, select } from "@clack/prompts";
 import { authenticationProviders } from "@ryuujs/generators";
 import { Either, Schema } from "effect";
 import { cancel } from "../../utils/cancel";
+import {
+	availableChoice,
+	choiceOptions,
+	unavailableMessage,
+} from "../../utils/choices";
 import { defineStep, SKIP } from "../types";
 
 export const authenticationSchema = Schema.Literal(
 	...authenticationProviders.ids,
-);
+).pipe(Schema.filter(availableChoice(authenticationProviders)));
 
 const authenticationStep = defineStep<typeof authenticationSchema.Type>({
 	id: "authentication",
@@ -33,21 +38,23 @@ const authenticationStep = defineStep<typeof authenticationSchema.Type>({
 			return SKIP;
 		}
 
-		const authentication = await select({
-			message: "What is your preferred way to handle authentication?",
-			options: [
-				...authenticationProviders.ids.map((option) => ({
-					label: authenticationProviders.label(option),
-					value: option,
-				})),
-				{ label: "None", value: "none" as const },
-			],
-		});
+		for (;;) {
+			const authentication = await select({
+				message: "What is your preferred way to handle authentication?",
+				options: [
+					...choiceOptions(authenticationProviders),
+					{ label: "None", value: "none" as const },
+				],
+			});
 
-		if (isCancel(authentication)) cancel();
-		if (authentication === "none") return SKIP;
+			if (isCancel(authentication)) cancel();
+			if (authentication === "none") return SKIP;
 
-		return authentication;
+			if (authenticationProviders.available(authentication))
+				return authentication;
+
+			log.warn(unavailableMessage(authenticationProviders, authentication));
+		}
 	},
 });
 

--- a/packages/cli/src/steps/backend/framework.ts
+++ b/packages/cli/src/steps/backend/framework.ts
@@ -1,10 +1,17 @@
-import { isCancel, select } from "@clack/prompts";
+import { isCancel, log, select } from "@clack/prompts";
 import { backends } from "@ryuujs/generators";
 import { Schema } from "effect";
 import { cancel } from "../../utils/cancel";
+import {
+	availableChoice,
+	choiceOptions,
+	unavailableMessage,
+} from "../../utils/choices";
 import { defineStep, SKIP, type Skip } from "../types";
 
-export const backendSchema = Schema.Literal(...backends.ids);
+export const backendSchema = Schema.Literal(...backends.ids).pipe(
+	Schema.filter(availableChoice(backends)),
+);
 
 export default defineStep<typeof backendSchema.Type>({
 	id: "backend",
@@ -20,30 +27,31 @@ export default defineStep<typeof backendSchema.Type>({
 	): Promise<typeof backendSchema.Type | Skip> {
 		if (!interactive) {
 			const normalized = backends.normalize(config.backend);
-			if (normalized) return normalized;
+			if (normalized && backends.available(normalized)) return normalized;
 
 			return SKIP;
 		}
 
 		const web = config.web;
 
-		const backend = await select({
-			message: "What is your preferred backend framework?",
-			options: [
-				...backends.ids.map((backendId) => ({
-					label:
-						web === backendId
-							? `${backends.label(backendId)} (Recommended)`
-							: backends.label(backendId),
-					value: backendId,
-				})),
-				{ label: "None", value: "none" as const },
-			],
-		});
+		for (;;) {
+			const backend = await select({
+				message: "What is your preferred backend framework?",
+				options: [
+					...choiceOptions(backends).map((option) =>
+						web === option.value
+							? { ...option, label: `${option.label} (Recommended)` }
+							: option,
+					),
+					{ label: "None", value: "none" as const },
+				],
+			});
 
-		if (isCancel(backend)) cancel();
-		if (backend === "none") return SKIP;
+			if (isCancel(backend)) cancel();
+			if (backend === "none") return SKIP;
+			if (backends.available(backend)) return backend;
 
-		return backend;
+			log.warn(unavailableMessage(backends, backend));
+		}
 	},
 });

--- a/packages/cli/src/steps/backend/framework.ts
+++ b/packages/cli/src/steps/backend/framework.ts
@@ -5,7 +5,7 @@ import { cancel } from "../../utils/cancel";
 import {
 	availableChoice,
 	choiceOptions,
-	unavailableMessage,
+	unsupportedMessage,
 } from "../../utils/choices";
 import { defineStep, SKIP, type Skip } from "../types";
 
@@ -51,7 +51,7 @@ export default defineStep<typeof backendSchema.Type>({
 			if (backend === "none") return SKIP;
 			if (backends.available(backend)) return backend;
 
-			log.warn(unavailableMessage(backends, backend));
+			log.warn(unsupportedMessage(backends, [backend]));
 		}
 	},
 });

--- a/packages/cli/src/steps/index.ts
+++ b/packages/cli/src/steps/index.ts
@@ -3,7 +3,6 @@ import authCustomUI from "./auth/custom-ui";
 import authProvider from "./auth/provider";
 import backendFramework from "./backend/framework";
 import rpc from "./backend/rpc";
-import rpcPublic from "./backend/rpc-public";
 import database from "./data/database";
 import databaseProvider from "./data/database-provider";
 import orm from "./data/orm";
@@ -45,7 +44,6 @@ export const steps: Step[] = [
 
 	backendFramework,
 	rpc,
-	rpcPublic,
 
 	database,
 	orm,

--- a/packages/cli/src/steps/platforms/select.ts
+++ b/packages/cli/src/steps/platforms/select.ts
@@ -5,20 +5,20 @@ import {
 } from "@ryuujs/generators";
 import { Either, Schema } from "effect";
 import { cancel } from "../../utils/cancel";
-import { choiceOptions, unavailableMessage } from "../../utils/choices";
+import { choiceOptions, unsupportedMessage } from "../../utils/choices";
 import { defineStep, SKIP } from "../types";
 
 export const platformsSchema = Schema.NonEmptyArray(
 	Schema.Literal(...platformChoices.ids),
 ).pipe(
 	Schema.filter((values) => {
-		const unavailable = values.find(
+		const unavailable = values.filter(
 			(value) => !platformChoices.available(value),
 		);
 
-		return unavailable === undefined
+		return unavailable.length === 0
 			? undefined
-			: unavailableMessage(platformChoices, unavailable);
+			: unsupportedMessage(platformChoices, unavailable);
 	}),
 );
 
@@ -59,9 +59,7 @@ const platformsStep = defineStep<typeof platformsSchema.Type>({
 			);
 
 			if (unavailable.length > 0) {
-				for (const platform of unavailable)
-					log.warn(unavailableMessage(platformChoices, platform));
-
+				log.warn(unsupportedMessage(platformChoices, unavailable));
 				continue;
 			}
 

--- a/packages/cli/src/steps/platforms/select.ts
+++ b/packages/cli/src/steps/platforms/select.ts
@@ -1,14 +1,25 @@
-import { isCancel, multiselect } from "@clack/prompts";
+import { isCancel, log, multiselect } from "@clack/prompts";
 import {
 	type Platform,
 	platforms as platformChoices,
 } from "@ryuujs/generators";
 import { Either, Schema } from "effect";
 import { cancel } from "../../utils/cancel";
+import { choiceOptions, unavailableMessage } from "../../utils/choices";
 import { defineStep, SKIP } from "../types";
 
 export const platformsSchema = Schema.NonEmptyArray(
 	Schema.Literal(...platformChoices.ids),
+).pipe(
+	Schema.filter((values) => {
+		const unavailable = values.find(
+			(value) => !platformChoices.available(value),
+		);
+
+		return unavailable === undefined
+			? undefined
+			: unavailableMessage(platformChoices, unavailable);
+	}),
 );
 
 const platformsStep = defineStep<typeof platformsSchema.Type>({
@@ -33,24 +44,34 @@ const platformsStep = defineStep<typeof platformsSchema.Type>({
 			return SKIP;
 		}
 
-		const selectedPlatforms = await multiselect({
-			message: "What platforms do you want to support?",
-			required: true,
+		for (;;) {
+			const selectedPlatforms = await multiselect({
+				message: "What platforms do you want to support?",
+				required: true,
 
-			options: platformChoices.ids.map((platform) => ({
-				label: platformChoices.label(platform),
-				value: platform,
-			})),
-		});
+				options: choiceOptions(platformChoices),
+			});
 
-		if (isCancel(selectedPlatforms)) cancel();
+			if (isCancel(selectedPlatforms)) cancel();
 
-		const result =
-			Schema.decodeUnknownEither(platformsSchema)(selectedPlatforms);
+			const unavailable = selectedPlatforms.filter(
+				(platform) => !platformChoices.available(platform),
+			);
 
-		if (Either.isLeft(result)) return SKIP;
+			if (unavailable.length > 0) {
+				for (const platform of unavailable)
+					log.warn(unavailableMessage(platformChoices, platform));
 
-		return result.right;
+				continue;
+			}
+
+			const result =
+				Schema.decodeUnknownEither(platformsSchema)(selectedPlatforms);
+
+			if (Either.isLeft(result)) return SKIP;
+
+			return result.right;
+		}
 	},
 });
 

--- a/packages/cli/src/steps/platforms/web.ts
+++ b/packages/cli/src/steps/platforms/web.ts
@@ -5,7 +5,7 @@ import { cancel } from "../../utils/cancel";
 import {
 	availableChoice,
 	choiceOptions,
-	unavailableMessage,
+	unsupportedMessage,
 } from "../../utils/choices";
 import { defineStep } from "../types";
 
@@ -47,7 +47,7 @@ const webStep = defineStep<typeof webSchema.Type>({
 			if (isCancel(web)) cancel();
 			if (webFrameworks.available(web)) return web;
 
-			log.warn(unavailableMessage(webFrameworks, web));
+			log.warn(unsupportedMessage(webFrameworks, [web]));
 		}
 	},
 });

--- a/packages/cli/src/steps/platforms/web.ts
+++ b/packages/cli/src/steps/platforms/web.ts
@@ -1,10 +1,17 @@
-import { isCancel, select } from "@clack/prompts";
+import { isCancel, log, select } from "@clack/prompts";
 import { webFrameworks } from "@ryuujs/generators";
 import { Either, Schema } from "effect";
 import { cancel } from "../../utils/cancel";
+import {
+	availableChoice,
+	choiceOptions,
+	unavailableMessage,
+} from "../../utils/choices";
 import { defineStep } from "../types";
 
-export const webSchema = Schema.Literal(...webFrameworks.ids);
+export const webSchema = Schema.Literal(...webFrameworks.ids).pipe(
+	Schema.filter(availableChoice(webFrameworks)),
+);
 
 const webStep = defineStep<typeof webSchema.Type>({
 	id: "web",
@@ -27,20 +34,21 @@ const webStep = defineStep<typeof webSchema.Type>({
 			return "nextjs";
 		}
 
-		const web = await select({
-			message: "What is your preferred web framework?",
-			options: webFrameworks.ids.map((option, index) => ({
-				label:
+		for (;;) {
+			const web = await select({
+				message: "What is your preferred web framework?",
+				options: choiceOptions(webFrameworks).map((option, index) =>
 					index === 0
-						? `${webFrameworks.label(option)} (Recommended)`
-						: webFrameworks.label(option),
-				value: option,
-			})),
-		});
+						? { ...option, label: `${option.label} (Recommended)` }
+						: option,
+				),
+			});
 
-		if (isCancel(web)) cancel();
+			if (isCancel(web)) cancel();
+			if (webFrameworks.available(web)) return web;
 
-		return web;
+			log.warn(unavailableMessage(webFrameworks, web));
+		}
 	},
 });
 

--- a/packages/cli/src/steps/project/linter.ts
+++ b/packages/cli/src/steps/project/linter.ts
@@ -5,7 +5,7 @@ import { cancel } from "../../utils/cancel";
 import {
 	availableChoice,
 	choiceOptions,
-	unavailableMessage,
+	unsupportedMessage,
 } from "../../utils/choices";
 import { defineStep, SKIP } from "../types";
 
@@ -45,7 +45,7 @@ const linterStep = defineStep<typeof linterSchema.Type>({
 			if (linter === "none") return SKIP;
 			if (linters.available(linter)) return linter;
 
-			log.warn(unavailableMessage(linters, linter));
+			log.warn(unsupportedMessage(linters, [linter]));
 		}
 	},
 });

--- a/packages/cli/src/steps/project/linter.ts
+++ b/packages/cli/src/steps/project/linter.ts
@@ -1,10 +1,17 @@
-import { isCancel, select } from "@clack/prompts";
+import { isCancel, log, select } from "@clack/prompts";
 import { linters } from "@ryuujs/generators";
 import { Either, Schema } from "effect";
 import { cancel } from "../../utils/cancel";
+import {
+	availableChoice,
+	choiceOptions,
+	unavailableMessage,
+} from "../../utils/choices";
 import { defineStep, SKIP } from "../types";
 
-export const linterSchema = Schema.Literal(...linters.ids);
+export const linterSchema = Schema.Literal(...linters.ids).pipe(
+	Schema.filter(availableChoice(linters)),
+);
 
 const linterStep = defineStep<typeof linterSchema.Type>({
 	id: "linter",
@@ -25,21 +32,21 @@ const linterStep = defineStep<typeof linterSchema.Type>({
 			return SKIP;
 		}
 
-		const linter = await select({
-			message: "What is your preferred linter/formatter?",
-			options: [
-				...linters.ids.map((option) => ({
-					label: linters.label(option),
-					value: option,
-				})),
-				{ label: "None", value: "none" as const },
-			],
-		});
+		for (;;) {
+			const linter = await select({
+				message: "What is your preferred linter/formatter?",
+				options: [
+					...choiceOptions(linters),
+					{ label: "None", value: "none" as const },
+				],
+			});
 
-		if (isCancel(linter)) cancel();
-		if (linter === "none") return SKIP;
+			if (isCancel(linter)) cancel();
+			if (linter === "none") return SKIP;
+			if (linters.available(linter)) return linter;
 
-		return linter;
+			log.warn(unavailableMessage(linters, linter));
+		}
 	},
 });
 

--- a/packages/cli/src/steps/style/web-framework.ts
+++ b/packages/cli/src/steps/style/web-framework.ts
@@ -1,4 +1,4 @@
-import { isCancel, select } from "@clack/prompts";
+import { isCancel, log, select } from "@clack/prompts";
 import {
 	desktopFrameworks,
 	styleFrameworks,
@@ -6,10 +6,17 @@ import {
 } from "@ryuujs/generators";
 import { Either, Schema } from "effect";
 import { cancel } from "../../utils/cancel";
+import {
+	availableChoice,
+	choiceOptions,
+	unavailableMessage,
+} from "../../utils/choices";
 import { stripNulls } from "../../utils/strip-nulls";
 import { defineStep, SKIP } from "../types";
 
-export const styleFrameworkSchema = Schema.Literal(...styleFrameworks.ids);
+export const styleFrameworkSchema = Schema.Literal(...styleFrameworks.ids).pipe(
+	Schema.filter(availableChoice(styleFrameworks)),
+);
 
 const styleFrameworkStep = defineStep<typeof styleFrameworkSchema.Type>({
 	id: "styleFramework",
@@ -32,24 +39,24 @@ const styleFrameworkStep = defineStep<typeof styleFrameworkSchema.Type>({
 			return SKIP;
 		}
 
-		const styleFramework = await select({
-			message: `Which styling framework do you want to use for ${stripNulls([
-				config.web ? webFrameworks.label(config.web) : null,
-				config.desktop ? desktopFrameworks.label(config.desktop) : null,
-			]).join(" and ")}?`,
-			options: [
-				...styleFrameworks.ids.map((option) => ({
-					label: styleFrameworks.label(option),
-					value: option,
-				})),
-				{ label: "None", value: "none" as const },
-			],
-		});
+		for (;;) {
+			const styleFramework = await select({
+				message: `Which styling framework do you want to use for ${stripNulls([
+					config.web ? webFrameworks.label(config.web) : null,
+					config.desktop ? desktopFrameworks.label(config.desktop) : null,
+				]).join(" and ")}?`,
+				options: [
+					...choiceOptions(styleFrameworks),
+					{ label: "None", value: "none" as const },
+				],
+			});
 
-		if (isCancel(styleFramework)) cancel();
-		if (styleFramework === "none") return SKIP;
+			if (isCancel(styleFramework)) cancel();
+			if (styleFramework === "none") return SKIP;
+			if (styleFrameworks.available(styleFramework)) return styleFramework;
 
-		return styleFramework;
+			log.warn(unavailableMessage(styleFrameworks, styleFramework));
+		}
 	},
 });
 

--- a/packages/cli/src/steps/style/web-framework.ts
+++ b/packages/cli/src/steps/style/web-framework.ts
@@ -9,7 +9,7 @@ import { cancel } from "../../utils/cancel";
 import {
 	availableChoice,
 	choiceOptions,
-	unavailableMessage,
+	unsupportedMessage,
 } from "../../utils/choices";
 import { stripNulls } from "../../utils/strip-nulls";
 import { defineStep, SKIP } from "../types";
@@ -55,7 +55,7 @@ const styleFrameworkStep = defineStep<typeof styleFrameworkSchema.Type>({
 			if (styleFramework === "none") return SKIP;
 			if (styleFrameworks.available(styleFramework)) return styleFramework;
 
-			log.warn(unavailableMessage(styleFrameworks, styleFramework));
+			log.warn(unsupportedMessage(styleFrameworks, [styleFramework]));
 		}
 	},
 });

--- a/packages/cli/src/utils/choices.ts
+++ b/packages/cli/src/utils/choices.ts
@@ -1,0 +1,25 @@
+export interface Choices<Id extends string> {
+	readonly available: (id: Id) => boolean;
+	readonly ids: ReadonlyArray<Id>;
+	readonly label: (id: Id) => string;
+}
+
+export function unavailableMessage<Id extends string>(
+	choices: Choices<Id>,
+	id: Id,
+) {
+	return `${choices.label(id)} isn't available yet.`;
+}
+
+export function availableChoice<Id extends string>(choices: Choices<Id>) {
+	return (id: Id) =>
+		choices.available(id) ? undefined : unavailableMessage(choices, id);
+}
+
+export function choiceOptions<Id extends string>(choices: Choices<Id>) {
+	return choices.ids.map((id) => ({
+		label: choices.label(id),
+		value: id,
+		...(choices.available(id) ? {} : { hint: "coming soon" }),
+	}));
+}

--- a/packages/cli/src/utils/choices.ts
+++ b/packages/cli/src/utils/choices.ts
@@ -1,19 +1,21 @@
+import { listAnd } from "./list";
+
 export interface Choices<Id extends string> {
 	readonly available: (id: Id) => boolean;
 	readonly ids: ReadonlyArray<Id>;
 	readonly label: (id: Id) => string;
 }
 
-export function unavailableMessage<Id extends string>(
+export function unsupportedMessage<Id extends string>(
 	choices: Choices<Id>,
-	id: Id,
+	ids: ReadonlyArray<Id>,
 ) {
-	return `${choices.label(id)} isn't available yet.`;
+	return `We don't support ${listAnd.format(ids.map((id) => choices.label(id)))} yet.`;
 }
 
 export function availableChoice<Id extends string>(choices: Choices<Id>) {
 	return (id: Id) =>
-		choices.available(id) ? undefined : unavailableMessage(choices, id);
+		choices.available(id) ? undefined : unsupportedMessage(choices, [id]);
 }
 
 export function choiceOptions<Id extends string>(choices: Choices<Id>) {

--- a/packages/cli/src/utils/list.ts
+++ b/packages/cli/src/utils/list.ts
@@ -1,5 +1,2 @@
 export const listOr = new Intl.ListFormat("en", { type: "disjunction" });
 export const listAnd = new Intl.ListFormat("en", { type: "conjunction" });
-
-export const plural = (count: number, singular: string, pluralForm?: string) =>
-	count === 1 ? singular : (pluralForm ?? `${singular}s`);

--- a/packages/cli/tests/config-schema.test.ts
+++ b/packages/cli/tests/config-schema.test.ts
@@ -46,7 +46,7 @@ describe("assembleSchema", () => {
 			authentication: "authjs",
 		});
 
-		expect(decodeMessages(result)).toContain("Auth.js isn't available yet.");
+		expect(decodeMessages(result)).toContain("We don't support Auth.js yet.");
 	});
 
 	it("accepts the available authentication provider", () => {
@@ -72,7 +72,7 @@ describe("assembleSchema", () => {
 		});
 
 		expect(decodeMessages(result)).toContain(
-			"React Router isn't available yet.",
+			"We don't support React Router yet.",
 		);
 	});
 
@@ -86,7 +86,7 @@ describe("assembleSchema", () => {
 			backend: "hono",
 		});
 
-		expect(decodeMessages(result)).toContain("Hono isn't available yet.");
+		expect(decodeMessages(result)).toContain("We don't support Hono yet.");
 	});
 
 	it("rejects unavailable linters with a friendly sentence", () => {
@@ -99,7 +99,7 @@ describe("assembleSchema", () => {
 			linter: "oxc",
 		});
 
-		expect(decodeMessages(result)).toContain("Oxc isn't available yet.");
+		expect(decodeMessages(result)).toContain("We don't support Oxc yet.");
 	});
 
 	it("rejects unavailable style frameworks with a friendly sentence", () => {
@@ -112,7 +112,7 @@ describe("assembleSchema", () => {
 			style: "unocss",
 		});
 
-		expect(decodeMessages(result)).toContain("UnoCSS isn't available yet.");
+		expect(decodeMessages(result)).toContain("We don't support UnoCSS yet.");
 	});
 
 	it("requires a web framework when the web platform is selected", () => {
@@ -134,7 +134,7 @@ describe("assembleSchema", () => {
 			platforms: ["desktop"],
 		});
 
-		expect(decodeMessages(result)).toContain("Desktop isn't available yet.");
+		expect(decodeMessages(result)).toContain("We don't support Desktop yet.");
 	});
 
 	it("rejects the mobile platform while it isn't available", () => {
@@ -144,7 +144,20 @@ describe("assembleSchema", () => {
 			platforms: ["mobile"],
 		});
 
-		expect(decodeMessages(result)).toContain("Mobile isn't available yet.");
+		expect(decodeMessages(result)).toContain("We don't support Mobile yet.");
+	});
+
+	it("lists every unsupported platform in one sentence", () => {
+		const result = decodeConfig({
+			name: "Acme",
+			slug: "acme",
+			platforms: ["web", "desktop", "mobile"],
+			web: "nextjs",
+		});
+
+		expect(decodeMessages(result)).toContain(
+			"We don't support Desktop and Mobile yet.",
+		);
 	});
 
 	it("spreads schema shape fields from null-key steps into the struct", () => {

--- a/packages/cli/tests/config-schema.test.ts
+++ b/packages/cli/tests/config-schema.test.ts
@@ -36,6 +36,85 @@ describe("assembleSchema", () => {
 		});
 	});
 
+	it("rejects unavailable authentication providers with a friendly sentence", () => {
+		const result = decodeConfig({
+			name: "Acme",
+			slug: "acme",
+			path: "./acme",
+			platforms: ["web"],
+			web: "nextjs",
+			authentication: "authjs",
+		});
+
+		expect(decodeMessages(result)).toContain("Auth.js isn't available yet.");
+	});
+
+	it("accepts the available authentication provider", () => {
+		const result = decodeConfig({
+			name: "Acme",
+			slug: "acme",
+			path: "./acme",
+			platforms: ["web"],
+			web: "nextjs",
+			authentication: "better-auth",
+		});
+
+		expect(Either.isRight(result)).toBe(true);
+	});
+
+	it("rejects unavailable web frameworks with a friendly sentence", () => {
+		const result = decodeConfig({
+			name: "Acme",
+			slug: "acme",
+			path: "./acme",
+			platforms: ["web"],
+			web: "react-router",
+		});
+
+		expect(decodeMessages(result)).toContain(
+			"React Router isn't available yet.",
+		);
+	});
+
+	it("rejects unavailable backends with a friendly sentence", () => {
+		const result = decodeConfig({
+			name: "Acme",
+			slug: "acme",
+			path: "./acme",
+			platforms: ["web"],
+			web: "nextjs",
+			backend: "hono",
+		});
+
+		expect(decodeMessages(result)).toContain("Hono isn't available yet.");
+	});
+
+	it("rejects unavailable linters with a friendly sentence", () => {
+		const result = decodeConfig({
+			name: "Acme",
+			slug: "acme",
+			path: "./acme",
+			platforms: ["web"],
+			web: "nextjs",
+			linter: "oxc",
+		});
+
+		expect(decodeMessages(result)).toContain("Oxc isn't available yet.");
+	});
+
+	it("rejects unavailable style frameworks with a friendly sentence", () => {
+		const result = decodeConfig({
+			name: "Acme",
+			slug: "acme",
+			path: "./acme",
+			platforms: ["web"],
+			web: "nextjs",
+			style: "unocss",
+		});
+
+		expect(decodeMessages(result)).toContain("UnoCSS isn't available yet.");
+	});
+
 	it("requires a web framework when the web platform is selected", () => {
 		const result = decodeConfig({
 			name: "Acme",
@@ -48,28 +127,24 @@ describe("assembleSchema", () => {
 		]);
 	});
 
-	it("requires a desktop framework when the desktop platform is selected", () => {
+	it("rejects the desktop platform while it isn't available", () => {
 		const result = decodeConfig({
 			name: "Acme",
 			slug: "acme",
 			platforms: ["desktop"],
 		});
 
-		expect(decodeMessages(result)).toEqual([
-			"A desktop framework wasn't selected.",
-		]);
+		expect(decodeMessages(result)).toContain("Desktop isn't available yet.");
 	});
 
-	it("requires a mobile framework when the mobile platform is selected", () => {
+	it("rejects the mobile platform while it isn't available", () => {
 		const result = decodeConfig({
 			name: "Acme",
 			slug: "acme",
 			platforms: ["mobile"],
 		});
 
-		expect(decodeMessages(result)).toEqual([
-			"A mobile framework wasn't selected.",
-		]);
+		expect(decodeMessages(result)).toContain("Mobile isn't available yet.");
 	});
 
 	it("spreads schema shape fields from null-key steps into the struct", () => {

--- a/packages/cli/tests/steps-auth.test.ts
+++ b/packages/cli/tests/steps-auth.test.ts
@@ -100,7 +100,7 @@ describe("authentication step", () => {
 		);
 
 		expect(promptMocks.logWarn).toHaveBeenCalledWith(
-			"WorkOS isn't available yet.",
+			"We don't support WorkOS yet.",
 		);
 		expect(promptMocks.select).toHaveBeenCalledTimes(2);
 	});

--- a/packages/cli/tests/steps-auth.test.ts
+++ b/packages/cli/tests/steps-auth.test.ts
@@ -7,6 +7,7 @@ const promptMocks = vi.hoisted(() => ({
 	cancel: vi.fn(),
 	confirm: vi.fn(),
 	isCancel: vi.fn(),
+	logWarn: vi.fn(),
 	select: vi.fn(),
 }));
 
@@ -14,6 +15,7 @@ vi.mock("@clack/prompts", () => ({
 	cancel: promptMocks.cancel,
 	confirm: promptMocks.confirm,
 	isCancel: promptMocks.isCancel,
+	log: { warn: promptMocks.logWarn },
 	select: promptMocks.select,
 }));
 
@@ -27,6 +29,7 @@ describe("authentication step", () => {
 		promptMocks.cancel.mockReset();
 		promptMocks.confirm.mockReset();
 		promptMocks.isCancel.mockReset();
+		promptMocks.logWarn.mockReset();
 		promptMocks.select.mockReset();
 		promptMocks.isCancel.mockReturnValue(false);
 	});
@@ -46,8 +49,17 @@ describe("authentication step", () => {
 
 	it("normalizes display-name aliases in non-interactive mode", async () => {
 		await expect(
+			authenticationStep.execute(
+				rawConfig({ authentication: "Better Auth" }),
+				false,
+			),
+		).resolves.toBe("better-auth");
+	});
+
+	it("skips unavailable providers in non-interactive mode", async () => {
+		await expect(
 			authenticationStep.execute(rawConfig({ authentication: "Clerk" }), false),
-		).resolves.toBe("clerk");
+		).resolves.toBe(SKIP);
 	});
 
 	it("skips when the configured provider is unknown", async () => {
@@ -60,20 +72,37 @@ describe("authentication step", () => {
 	});
 
 	it("returns the selected provider", async () => {
-		promptMocks.select.mockResolvedValue("workos");
+		promptMocks.select.mockResolvedValue("better-auth");
 
-		await expect(authenticationStep.execute({}, true)).resolves.toBe("workos");
+		await expect(authenticationStep.execute({}, true)).resolves.toBe(
+			"better-auth",
+		);
 
 		expect(promptMocks.select).toHaveBeenCalledWith({
 			message: "What is your preferred way to handle authentication?",
 			options: [
 				{ label: "Better Auth", value: "better-auth" },
-				{ label: "Auth.js", value: "authjs" },
-				{ label: "WorkOS", value: "workos" },
-				{ label: "Clerk", value: "clerk" },
+				{ label: "Auth.js", value: "authjs", hint: "coming soon" },
+				{ label: "WorkOS", value: "workos", hint: "coming soon" },
+				{ label: "Clerk", value: "clerk", hint: "coming soon" },
 				{ label: "None", value: "none" },
 			],
 		});
+	});
+
+	it("explains and re-prompts when an unavailable provider is selected", async () => {
+		promptMocks.select
+			.mockResolvedValueOnce("workos")
+			.mockResolvedValueOnce("better-auth");
+
+		await expect(authenticationStep.execute({}, true)).resolves.toBe(
+			"better-auth",
+		);
+
+		expect(promptMocks.logWarn).toHaveBeenCalledWith(
+			"WorkOS isn't available yet.",
+		);
+		expect(promptMocks.select).toHaveBeenCalledTimes(2);
 	});
 
 	it("skips when none is selected", async () => {
@@ -88,6 +117,7 @@ describe("authenticationCustomUI step", () => {
 		promptMocks.cancel.mockReset();
 		promptMocks.confirm.mockReset();
 		promptMocks.isCancel.mockReset();
+		promptMocks.logWarn.mockReset();
 		promptMocks.select.mockReset();
 		promptMocks.isCancel.mockReturnValue(false);
 	});

--- a/packages/cli/tests/steps-backend.test.ts
+++ b/packages/cli/tests/steps-backend.test.ts
@@ -8,6 +8,7 @@ const promptMocks = vi.hoisted(() => ({
 	cancel: vi.fn(),
 	confirm: vi.fn(),
 	isCancel: vi.fn(),
+	logWarn: vi.fn(),
 	select: vi.fn(),
 }));
 
@@ -15,6 +16,7 @@ vi.mock("@clack/prompts", () => ({
 	cancel: promptMocks.cancel,
 	confirm: promptMocks.confirm,
 	isCancel: promptMocks.isCancel,
+	log: { warn: promptMocks.logWarn },
 	select: promptMocks.select,
 }));
 
@@ -28,22 +30,29 @@ describe("backend step", () => {
 		promptMocks.cancel.mockReset();
 		promptMocks.confirm.mockReset();
 		promptMocks.isCancel.mockReset();
+		promptMocks.logWarn.mockReset();
 		promptMocks.select.mockReset();
 		promptMocks.isCancel.mockReturnValue(false);
 	});
 
 	it("accepts a canonical backend id without prompting", async () => {
-		await expect(backendStep.execute({ backend: "hono" }, false)).resolves.toBe(
-			"hono",
-		);
+		await expect(
+			backendStep.execute({ backend: "nextjs" }, false),
+		).resolves.toBe("nextjs");
 
 		expect(promptMocks.select).not.toHaveBeenCalled();
 	});
 
 	it("normalizes display-name aliases in non-interactive mode", async () => {
 		await expect(
-			backendStep.execute(rawConfig({ backend: "Hono" }), false),
-		).resolves.toBe("hono");
+			backendStep.execute(rawConfig({ backend: "Next.js" }), false),
+		).resolves.toBe("nextjs");
+	});
+
+	it("skips unavailable backends in non-interactive mode", async () => {
+		await expect(backendStep.execute({ backend: "hono" }, false)).resolves.toBe(
+			SKIP,
+		);
 	});
 
 	it("skips when the configured backend is unknown", async () => {
@@ -53,25 +62,38 @@ describe("backend step", () => {
 	});
 
 	it("marks the chosen web framework as recommended", async () => {
-		promptMocks.select.mockResolvedValue("hono");
+		promptMocks.select.mockResolvedValue("nextjs");
 
 		await expect(backendStep.execute({ web: "nextjs" }, true)).resolves.toBe(
-			"hono",
+			"nextjs",
 		);
 
 		expect(promptMocks.select).toHaveBeenCalledWith({
 			message: "What is your preferred backend framework?",
 			options: [
 				{ label: "Next.js (Recommended)", value: "nextjs" },
-				{ label: "Convex", value: "convex" },
-				{ label: "Hono", value: "hono" },
-				{ label: "Elysia", value: "elysia" },
-				{ label: "µWebSockets", value: "uwebsockets" },
-				{ label: "Fastify", value: "fastify" },
-				{ label: "Express", value: "express" },
+				{ label: "Convex", value: "convex", hint: "coming soon" },
+				{ label: "Hono", value: "hono", hint: "coming soon" },
+				{ label: "Elysia", value: "elysia", hint: "coming soon" },
+				{ label: "µWebSockets", value: "uwebsockets", hint: "coming soon" },
+				{ label: "Fastify", value: "fastify", hint: "coming soon" },
+				{ label: "Express", value: "express", hint: "coming soon" },
 				{ label: "None", value: "none" },
 			],
 		});
+	});
+
+	it("warns and re-prompts when an unavailable backend is selected", async () => {
+		promptMocks.select
+			.mockResolvedValueOnce("hono")
+			.mockResolvedValueOnce("nextjs");
+
+		await expect(backendStep.execute({}, true)).resolves.toBe("nextjs");
+
+		expect(promptMocks.logWarn).toHaveBeenCalledWith(
+			"Hono isn't available yet.",
+		);
+		expect(promptMocks.select).toHaveBeenCalledTimes(2);
 	});
 
 	it("skips when none is selected", async () => {
@@ -107,6 +129,7 @@ describe("rpc step", () => {
 		promptMocks.cancel.mockReset();
 		promptMocks.confirm.mockReset();
 		promptMocks.isCancel.mockReset();
+		promptMocks.logWarn.mockReset();
 		promptMocks.select.mockReset();
 		promptMocks.isCancel.mockReturnValue(false);
 	});
@@ -171,6 +194,7 @@ describe("rpcPublic step", () => {
 		promptMocks.cancel.mockReset();
 		promptMocks.confirm.mockReset();
 		promptMocks.isCancel.mockReset();
+		promptMocks.logWarn.mockReset();
 		promptMocks.select.mockReset();
 		promptMocks.isCancel.mockReturnValue(false);
 	});

--- a/packages/cli/tests/steps-backend.test.ts
+++ b/packages/cli/tests/steps-backend.test.ts
@@ -91,7 +91,7 @@ describe("backend step", () => {
 		await expect(backendStep.execute({}, true)).resolves.toBe("nextjs");
 
 		expect(promptMocks.logWarn).toHaveBeenCalledWith(
-			"Hono isn't available yet.",
+			"We don't support Hono yet.",
 		);
 		expect(promptMocks.select).toHaveBeenCalledTimes(2);
 	});

--- a/packages/cli/tests/steps-platforms.test.ts
+++ b/packages/cli/tests/steps-platforms.test.ts
@@ -6,12 +6,14 @@ import webStep from "../src/steps/platforms/web";
 import { type PartialConfig, SKIP } from "../src/steps/types";
 
 const promptMocks = vi.hoisted(() => ({
+	logWarn: vi.fn(),
 	multiselect: vi.fn(),
 	select: vi.fn(),
 }));
 
 vi.mock("@clack/prompts", () => ({
 	isCancel: () => false,
+	log: { warn: promptMocks.logWarn },
 	multiselect: promptMocks.multiselect,
 	select: promptMocks.select,
 }));
@@ -25,6 +27,7 @@ function rawConfig(entries: Record<string, unknown>): PartialConfig {
 }
 
 beforeEach(() => {
+	promptMocks.logWarn.mockReset();
 	promptMocks.multiselect.mockReset();
 	promptMocks.select.mockReset();
 });
@@ -32,8 +35,17 @@ beforeEach(() => {
 describe("platforms step", () => {
 	it("keeps a valid platform list when non-interactive", async () => {
 		await expect(
+			platformsStep.execute({ platforms: ["web"] }, false),
+		).resolves.toEqual(["web"]);
+	});
+
+	it("skips when the list contains an unavailable platform", async () => {
+		await expect(
 			platformsStep.execute({ platforms: ["web", "mobile"] }, false),
-		).resolves.toEqual(["web", "mobile"]);
+		).resolves.toBe(SKIP);
+		await expect(
+			platformsStep.execute({ platforms: ["desktop"] }, false),
+		).resolves.toBe(SKIP);
 	});
 
 	it("silently filters unknown platforms when non-interactive", async () => {
@@ -55,19 +67,32 @@ describe("platforms step", () => {
 	});
 
 	it("returns the interactive multiselect choice", async () => {
-		promptMocks.multiselect.mockResolvedValue(["desktop"]);
+		promptMocks.multiselect.mockResolvedValue(["web"]);
 
-		await expect(platformsStep.execute({}, true)).resolves.toEqual(["desktop"]);
+		await expect(platformsStep.execute({}, true)).resolves.toEqual(["web"]);
 
 		expect(promptMocks.multiselect).toHaveBeenCalledWith({
 			message: "What platforms do you want to support?",
 			options: [
 				{ label: "Web", value: "web" },
-				{ label: "Desktop", value: "desktop" },
-				{ label: "Mobile", value: "mobile" },
+				{ label: "Desktop", value: "desktop", hint: "coming soon" },
+				{ label: "Mobile", value: "mobile", hint: "coming soon" },
 			],
 			required: true,
 		});
+	});
+
+	it("warns and re-prompts when an unavailable platform is selected", async () => {
+		promptMocks.multiselect
+			.mockResolvedValueOnce(["web", "desktop"])
+			.mockResolvedValueOnce(["web"]);
+
+		await expect(platformsStep.execute({}, true)).resolves.toEqual(["web"]);
+
+		expect(promptMocks.logWarn).toHaveBeenCalledWith(
+			"Desktop isn't available yet.",
+		);
+		expect(promptMocks.multiselect).toHaveBeenCalledTimes(2);
 	});
 
 	it("skips when the interactive selection is empty", async () => {
@@ -85,9 +110,9 @@ describe("web step", () => {
 	});
 
 	it("keeps a valid web framework when non-interactive", async () => {
-		await expect(
-			webStep.execute({ web: "tanstack-router" }, false),
-		).resolves.toBe("tanstack-router");
+		await expect(webStep.execute({ web: "nextjs" }, false)).resolves.toBe(
+			"nextjs",
+		);
 	});
 
 	it("defaults to nextjs when web is missing", async () => {
@@ -100,20 +125,47 @@ describe("web step", () => {
 		).resolves.toBe("nextjs");
 	});
 
-	it("recommends the first option and returns the interactive choice", async () => {
-		promptMocks.select.mockResolvedValue("react-router");
+	it("silently defaults to nextjs when web is unavailable", async () => {
+		await expect(webStep.execute({ web: "react-router" }, false)).resolves.toBe(
+			"nextjs",
+		);
+	});
 
-		await expect(webStep.execute({}, true)).resolves.toBe("react-router");
+	it("recommends the first option and returns the interactive choice", async () => {
+		promptMocks.select.mockResolvedValue("nextjs");
+
+		await expect(webStep.execute({}, true)).resolves.toBe("nextjs");
 
 		expect(promptMocks.select).toHaveBeenCalledWith({
 			message: "What is your preferred web framework?",
 			options: [
 				{ label: "Next.js (Recommended)", value: "nextjs" },
-				{ label: "React Router", value: "react-router" },
-				{ label: "TanStack Router", value: "tanstack-router" },
-				{ label: "TanStack Start", value: "tanstack-start" },
+				{ label: "React Router", value: "react-router", hint: "coming soon" },
+				{
+					label: "TanStack Router",
+					value: "tanstack-router",
+					hint: "coming soon",
+				},
+				{
+					label: "TanStack Start",
+					value: "tanstack-start",
+					hint: "coming soon",
+				},
 			],
 		});
+	});
+
+	it("warns and re-prompts when an unavailable web framework is selected", async () => {
+		promptMocks.select
+			.mockResolvedValueOnce("react-router")
+			.mockResolvedValueOnce("nextjs");
+
+		await expect(webStep.execute({}, true)).resolves.toBe("nextjs");
+
+		expect(promptMocks.logWarn).toHaveBeenCalledWith(
+			"React Router isn't available yet.",
+		);
+		expect(promptMocks.select).toHaveBeenCalledTimes(2);
 	});
 });
 

--- a/packages/cli/tests/steps-platforms.test.ts
+++ b/packages/cli/tests/steps-platforms.test.ts
@@ -90,9 +90,22 @@ describe("platforms step", () => {
 		await expect(platformsStep.execute({}, true)).resolves.toEqual(["web"]);
 
 		expect(promptMocks.logWarn).toHaveBeenCalledWith(
-			"Desktop isn't available yet.",
+			"We don't support Desktop yet.",
 		);
 		expect(promptMocks.multiselect).toHaveBeenCalledTimes(2);
+	});
+
+	it("lists every unsupported platform in one warning", async () => {
+		promptMocks.multiselect
+			.mockResolvedValueOnce(["web", "desktop", "mobile"])
+			.mockResolvedValueOnce(["web"]);
+
+		await expect(platformsStep.execute({}, true)).resolves.toEqual(["web"]);
+
+		expect(promptMocks.logWarn).toHaveBeenCalledTimes(1);
+		expect(promptMocks.logWarn).toHaveBeenCalledWith(
+			"We don't support Desktop and Mobile yet.",
+		);
 	});
 
 	it("skips when the interactive selection is empty", async () => {
@@ -163,7 +176,7 @@ describe("web step", () => {
 		await expect(webStep.execute({}, true)).resolves.toBe("nextjs");
 
 		expect(promptMocks.logWarn).toHaveBeenCalledWith(
-			"React Router isn't available yet.",
+			"We don't support React Router yet.",
 		);
 		expect(promptMocks.select).toHaveBeenCalledTimes(2);
 	});

--- a/packages/cli/tests/steps-project.test.ts
+++ b/packages/cli/tests/steps-project.test.ts
@@ -319,7 +319,7 @@ describe("project steps", () => {
 			await expect(linterStep.execute({}, true)).resolves.toBe("biome");
 
 			expect(promptMocks.logWarn).toHaveBeenCalledWith(
-				"Oxc isn't available yet.",
+				"We don't support Oxc yet.",
 			);
 			expect(promptMocks.select).toHaveBeenCalledTimes(2);
 		});

--- a/packages/cli/tests/steps-project.test.ts
+++ b/packages/cli/tests/steps-project.test.ts
@@ -9,6 +9,7 @@ import { type PartialConfig, SKIP } from "../src/steps/types";
 
 const promptMocks = vi.hoisted(() => ({
 	logError: vi.fn(),
+	logWarn: vi.fn(),
 	select: vi.fn(),
 	text: vi.fn(),
 }));
@@ -20,7 +21,7 @@ const coreMocks = vi.hoisted(() => ({
 vi.mock("@clack/prompts", () => ({
 	cancel: vi.fn(),
 	isCancel: () => false,
-	log: { error: promptMocks.logError },
+	log: { error: promptMocks.logError, warn: promptMocks.logWarn },
 	select: promptMocks.select,
 	text: promptMocks.text,
 }));
@@ -50,6 +51,7 @@ describe("project steps", () => {
 	beforeEach(() => {
 		coreMocks.checkPackageManager.mockReset();
 		promptMocks.logError.mockReset();
+		promptMocks.logWarn.mockReset();
 		promptMocks.select.mockReset();
 		promptMocks.text.mockReset();
 	});
@@ -282,6 +284,12 @@ describe("project steps", () => {
 			).resolves.toBe(SKIP);
 		});
 
+		it("skips an unavailable linter when non-interactive", async () => {
+			await expect(linterStep.execute({ linter: "oxc" }, false)).resolves.toBe(
+				SKIP,
+			);
+		});
+
 		it("returns the selected linter", async () => {
 			promptMocks.select.mockResolvedValue("biome");
 
@@ -291,12 +299,29 @@ describe("project steps", () => {
 				expect.objectContaining({
 					options: [
 						{ label: "Biome", value: "biome" },
-						{ label: "Oxc", value: "oxc" },
-						{ label: "ESLint + Prettier", value: "eslint-prettier" },
+						{ label: "Oxc", value: "oxc", hint: "coming soon" },
+						{
+							label: "ESLint + Prettier",
+							value: "eslint-prettier",
+							hint: "coming soon",
+						},
 						{ label: "None", value: "none" },
 					],
 				}),
 			);
+		});
+
+		it("warns and re-prompts when an unavailable linter is selected", async () => {
+			promptMocks.select
+				.mockResolvedValueOnce("oxc")
+				.mockResolvedValueOnce("biome");
+
+			await expect(linterStep.execute({}, true)).resolves.toBe("biome");
+
+			expect(promptMocks.logWarn).toHaveBeenCalledWith(
+				"Oxc isn't available yet.",
+			);
+			expect(promptMocks.select).toHaveBeenCalledTimes(2);
 		});
 
 		it("skips when None is selected", async () => {

--- a/packages/cli/tests/steps-style.test.ts
+++ b/packages/cli/tests/steps-style.test.ts
@@ -8,12 +8,14 @@ import { type PartialConfig, SKIP } from "../src/steps/types";
 const promptMocks = vi.hoisted(() => ({
 	cancel: vi.fn(),
 	isCancel: vi.fn(),
+	logWarn: vi.fn(),
 	select: vi.fn(),
 }));
 
 vi.mock("@clack/prompts", () => ({
 	cancel: promptMocks.cancel,
 	isCancel: promptMocks.isCancel,
+	log: { warn: promptMocks.logWarn },
 	select: promptMocks.select,
 }));
 
@@ -29,6 +31,7 @@ beforeEach(() => {
 	promptMocks.cancel.mockReset();
 	promptMocks.isCancel.mockReset();
 	promptMocks.isCancel.mockReturnValue(false);
+	promptMocks.logWarn.mockReset();
 	promptMocks.select.mockReset();
 });
 
@@ -52,6 +55,12 @@ describe("style framework step", () => {
 		).resolves.toBe(SKIP);
 	});
 
+	it("skips an unavailable style framework when non-interactive", async () => {
+		await expect(
+			styleFrameworkStep.execute({ style: "unocss" }, false),
+		).resolves.toBe(SKIP);
+	});
+
 	it("joins the selected framework labels in the interactive message", async () => {
 		promptMocks.select.mockResolvedValue("tailwind");
 
@@ -64,24 +73,39 @@ describe("style framework step", () => {
 				"Which styling framework do you want to use for Next.js and Electron?",
 			options: [
 				{ label: "Tailwind CSS", value: "tailwind" },
-				{ label: "UnoCSS", value: "unocss" },
+				{ label: "UnoCSS", value: "unocss", hint: "coming soon" },
 				{ label: "None", value: "none" },
 			],
 		});
 	});
 
 	it("drops absent frameworks from the interactive message", async () => {
-		promptMocks.select.mockResolvedValue("unocss");
+		promptMocks.select.mockResolvedValue("tailwind");
 
 		await expect(
 			styleFrameworkStep.execute({ web: "nextjs" }, true),
-		).resolves.toBe("unocss");
+		).resolves.toBe("tailwind");
 
 		expect(promptMocks.select).toHaveBeenCalledWith(
 			expect.objectContaining({
 				message: "Which styling framework do you want to use for Next.js?",
 			}),
 		);
+	});
+
+	it("warns and re-prompts when an unavailable style framework is selected", async () => {
+		promptMocks.select
+			.mockResolvedValueOnce("unocss")
+			.mockResolvedValueOnce("tailwind");
+
+		await expect(
+			styleFrameworkStep.execute({ web: "nextjs" }, true),
+		).resolves.toBe("tailwind");
+
+		expect(promptMocks.logWarn).toHaveBeenCalledWith(
+			"UnoCSS isn't available yet.",
+		);
+		expect(promptMocks.select).toHaveBeenCalledTimes(2);
 	});
 
 	it("skips when none is selected interactively", async () => {

--- a/packages/cli/tests/steps-style.test.ts
+++ b/packages/cli/tests/steps-style.test.ts
@@ -103,7 +103,7 @@ describe("style framework step", () => {
 		).resolves.toBe("tailwind");
 
 		expect(promptMocks.logWarn).toHaveBeenCalledWith(
-			"UnoCSS isn't available yet.",
+			"We don't support UnoCSS yet.",
 		);
 		expect(promptMocks.select).toHaveBeenCalledTimes(2);
 	});

--- a/packages/generators/src/config.ts
+++ b/packages/generators/src/config.ts
@@ -1,6 +1,9 @@
 import type { PackageManager, Runtime } from "@ryuujs/core";
 
-function defineChoices<const T extends Record<string, string>>(definitions: T) {
+function defineChoices<const T extends Record<string, string>>(
+	definitions: T,
+	options?: { unavailable?: ReadonlyArray<keyof T & string> },
+) {
 	type ChoiceId = keyof T & string;
 
 	const ids = Object.keys(definitions) as ReadonlyArray<ChoiceId>;
@@ -10,6 +13,7 @@ function defineChoices<const T extends Record<string, string>>(definitions: T) {
 		return value;
 	};
 	const byDisplayName = new Map(ids.map((id) => [read(id).toLowerCase(), id]));
+	const unavailable = new Set(options?.unavailable ?? []);
 
 	function normalize(value: unknown): ChoiceId | undefined {
 		if (typeof value !== "string") return undefined;
@@ -22,35 +26,68 @@ function defineChoices<const T extends Record<string, string>>(definitions: T) {
 		return read(id);
 	}
 
-	return { definitions, ids, label, normalize };
+	function available(id: ChoiceId): boolean {
+		return !unavailable.has(id);
+	}
+
+	return {
+		available,
+		availableIds: ids.filter(available),
+		definitions,
+		ids,
+		label,
+		normalize,
+	};
 }
 
-export const platforms = defineChoices({
-	web: "Web",
-	desktop: "Desktop",
-	mobile: "Mobile",
-} as const);
+export const platforms = defineChoices(
+	{
+		web: "Web",
+		desktop: "Desktop",
+		mobile: "Mobile",
+	} as const,
+	{
+		unavailable: ["desktop", "mobile"],
+	},
+);
 
 export type Platform = keyof typeof platforms.definitions;
 
-export const webFrameworks = defineChoices({
-	nextjs: "Next.js",
-	"react-router": "React Router",
-	"tanstack-router": "TanStack Router",
-	"tanstack-start": "TanStack Start",
-} as const);
+export const webFrameworks = defineChoices(
+	{
+		nextjs: "Next.js",
+		"react-router": "React Router",
+		"tanstack-router": "TanStack Router",
+		"tanstack-start": "TanStack Start",
+	} as const,
+	{
+		unavailable: ["react-router", "tanstack-router", "tanstack-start"],
+	},
+);
 
 export type WebFramework = keyof typeof webFrameworks.definitions;
 
-export const backends = defineChoices({
-	nextjs: "Next.js",
-	convex: "Convex",
-	hono: "Hono",
-	elysia: "Elysia",
-	uwebsockets: "µWebSockets",
-	fastify: "Fastify",
-	express: "Express",
-} as const);
+export const backends = defineChoices(
+	{
+		nextjs: "Next.js",
+		convex: "Convex",
+		hono: "Hono",
+		elysia: "Elysia",
+		uwebsockets: "µWebSockets",
+		fastify: "Fastify",
+		express: "Express",
+	} as const,
+	{
+		unavailable: [
+			"convex",
+			"hono",
+			"elysia",
+			"uwebsockets",
+			"fastify",
+			"express",
+		],
+	},
+);
 
 export type Backend = keyof typeof backends.definitions;
 
@@ -75,20 +112,30 @@ export const orms = defineChoices({
 
 export type Orm = keyof typeof orms.definitions;
 
-export const authenticationProviders = defineChoices({
-	"better-auth": "Better Auth",
-	authjs: "Auth.js",
-	workos: "WorkOS",
-	clerk: "Clerk",
-} as const);
+export const authenticationProviders = defineChoices(
+	{
+		"better-auth": "Better Auth",
+		authjs: "Auth.js",
+		workos: "WorkOS",
+		clerk: "Clerk",
+	} as const,
+	{
+		unavailable: ["authjs", "workos", "clerk"],
+	},
+);
 
 export type AuthenticationProvider =
 	keyof typeof authenticationProviders.definitions;
 
-export const styleFrameworks = defineChoices({
-	tailwind: "Tailwind CSS",
-	unocss: "UnoCSS",
-} as const);
+export const styleFrameworks = defineChoices(
+	{
+		tailwind: "Tailwind CSS",
+		unocss: "UnoCSS",
+	} as const,
+	{
+		unavailable: ["unocss"],
+	},
+);
 
 export type StyleFramework = keyof typeof styleFrameworks.definitions;
 
@@ -99,11 +146,16 @@ export const uiLibraries = defineChoices({
 
 export type UiLibrary = keyof typeof uiLibraries.definitions;
 
-export const linters = defineChoices({
-	biome: "Biome",
-	oxc: "Oxc",
-	"eslint-prettier": "ESLint + Prettier",
-} as const);
+export const linters = defineChoices(
+	{
+		biome: "Biome",
+		oxc: "Oxc",
+		"eslint-prettier": "ESLint + Prettier",
+	} as const,
+	{
+		unavailable: ["oxc", "eslint-prettier"],
+	},
+);
 
 export type Linter = keyof typeof linters.definitions;
 

--- a/packages/generators/tests/config.test.ts
+++ b/packages/generators/tests/config.test.ts
@@ -5,6 +5,7 @@ import {
 	configWithInstall,
 	configWithoutInstall,
 	databaseProviders,
+	databases,
 	desktopFrameworks,
 	installConflict,
 	linters,
@@ -12,6 +13,7 @@ import {
 	nativeStyleFrameworks,
 	optionalAddons,
 	orms,
+	platforms,
 	recommendedAddons,
 	rpcProviders,
 	styleFrameworks,
@@ -58,6 +60,24 @@ describe("generator config choices", () => {
 	it("only recommends known optional addons", () => {
 		for (const addon of recommendedAddons)
 			expect(optionalAddons.ids).toContain(addon);
+	});
+
+	it("marks roadmap-gated choices as unavailable", () => {
+		expect(platforms.availableIds).toEqual(["web"]);
+		expect(platforms.available("desktop")).toBe(false);
+		expect(webFrameworks.availableIds).toEqual(["nextjs"]);
+		expect(authenticationProviders.availableIds).toEqual(["better-auth"]);
+	});
+
+	it("keeps ungated choice sets fully available", () => {
+		expect(databases.availableIds).toEqual(databases.ids);
+		for (const id of databases.ids) expect(databases.available(id)).toBe(true);
+	});
+
+	it("normalizes gated values independently of availability", () => {
+		expect(authenticationProviders.normalize("Clerk")).toBe("clerk");
+		expect(authenticationProviders.label("clerk")).toBe("Clerk");
+		expect(authenticationProviders.available("clerk")).toBe(false);
 	});
 });
 

--- a/tests/scenarios/src/scenarios/create.test.ts
+++ b/tests/scenarios/src/scenarios/create.test.ts
@@ -154,7 +154,7 @@ describe("create", () => {
 
 				expect(result.exitCode).not.toBe(0);
 				expect(result.stdout + result.stderr).toContain(
-					"Desktop isn't available yet.",
+					"We don't support Desktop yet.",
 				);
 			},
 		);

--- a/tests/scenarios/src/scenarios/create.test.ts
+++ b/tests/scenarios/src/scenarios/create.test.ts
@@ -5,7 +5,9 @@ import {
 	createProject,
 	pathExists,
 	readJson,
+	tryRunForge,
 	withScenarioWorkspace,
+	writeJson,
 } from "../utils/harness";
 
 async function listProjectFiles(root: string, prefix = ""): Promise<string[]> {
@@ -128,5 +130,33 @@ describe("create", () => {
 
 			expect(await readdir(workspace.projectRoot)).toEqual([]);
 		});
+	}, 120_000);
+
+	it("rejects config files that select unavailable platforms", async () => {
+		await withScenarioWorkspace(
+			"create-unavailable-platform",
+			async (workspace) => {
+				const configPath = join(workspace.workspaceRoot, "forge.config.json");
+
+				await writeJson(configPath, {
+					name: "acme",
+					path: "./project",
+					platforms: ["web", "desktop"],
+					slug: "acme",
+					web: "nextjs",
+				});
+
+				const result = await tryRunForge(
+					workspace.workspaceRoot,
+					["create", "--config", configPath, "--no-install", "--no-git"],
+					{ workspaceRoot: workspace.workspaceRoot },
+				);
+
+				expect(result.exitCode).not.toBe(0);
+				expect(result.stdout + result.stderr).toContain(
+					"Desktop isn't available yet.",
+				);
+			},
+		);
 	}, 120_000);
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a "coming soon" gating mechanism for roadmap-locked choices across the CLI wizard. Unavailable options are shown in every prompt with a `hint: "coming soon"` label, selecting one triggers a friendly warning and re-prompts the user, and specifying one in a config file is rejected with a clear error message at both the schema-validation and step-execution layers.

- `defineChoices` in `packages/generators/src/config.ts` gains an `unavailable` list; the resulting `available()` function and `availableIds` field are used uniformly in all step schemas and execute functions.
- A new `packages/cli/src/utils/choices.ts` utility centralises the three helpers (`choiceOptions`, `availableChoice`, `unavailableMessage`) so every prompt file stays consistent.
- All affected steps (`auth/provider`, `backend/framework`, `platforms/select`, `platforms/web`, `project/linter`, `style/web-framework`) are updated to a `for(;;)` re-prompt loop and a SKIP-on-unavailable path for non-interactive mode, each covered by new unit and scenario tests.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is additive and well-tested, with one minor UX rough edge in error reporting for the non-interactive path.

The gating logic is implemented consistently across all affected steps, schema filters and execute paths agree, and both unit and end-to-end tests cover the new behaviour. The one rough edge is that when a config file lists multiple unavailable platforms (e.g. ["desktop", "mobile"]), the schema filter uses `find` and surfaces only the first rejection message — the user would have to fix and re-run to discover the second. This is a UX gap, not a correctness bug, so it doesn't block the change.

packages/cli/src/steps/platforms/select.ts — the platformsSchema filter reports only the first unavailable platform; all other files look correct.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/choices.ts | New utility module introducing Choices interface, choiceOptions (adds hint: "coming soon"), availableChoice (schema filter helper), and unavailableMessage — clean and consistent across all callers. |
| packages/generators/src/config.ts | defineChoices gains an optional unavailable list; exposes available() and availableIds. Roadmap-gated choices correctly marked for platforms, webFrameworks, backends, authenticationProviders, styleFrameworks, and linters. |
| packages/cli/src/steps/platforms/select.ts | platformsSchema now filters unavailable platforms; interactive loop warns and re-prompts per-platform. Schema filter only surfaces the first unavailable item in non-interactive error messages (see inline comment). |
| packages/cli/src/steps/platforms/web.ts | webStep non-interactive path silently defaults to "nextjs" when an unavailable framework is specified — consistent with its pre-existing fallback and prevented in practice by config-level schema validation. |
| packages/cli/src/steps/auth/provider.ts | Authentication step now uses schema decode for availability gating in non-interactive mode and a for(;;) loop with warn+re-prompt in interactive mode — correct and well-tested. |
| packages/cli/src/steps/backend/framework.ts | Backend step returns SKIP for unavailable selections in non-interactive mode and re-prompts with a warning in interactive mode. "Recommended" label mapping preserved correctly. |
| packages/cli/src/steps/index.ts | rpcPublic step removed from the orchestrator step list; step file still exists and is tested directly, so nothing breaks. |
| packages/cli/tests/config-schema.test.ts | Tests updated to cover unavailability rejections for auth, web frameworks, backends, linters, and style frameworks; desktop/mobile platform rejection tests corrected. |
| tests/scenarios/src/scenarios/create.test.ts | New end-to-end scenario asserts that a config file with an unavailable platform produces a non-zero exit code and a human-readable error message. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User selects an option] --> B{available?}
    B -- Yes --> C[Return selection]
    B -- No --> D[log.warn: X isn't available yet.]
    D --> A

    E[Config file / non-interactive] --> F{normalize value}
    F -- unknown --> G[Return SKIP]
    F -- known --> H{available?}
    H -- Yes --> I[Return value]
    H -- No --> G

    J[assembleSchema validation] --> K{Schema.filter availableChoice}
    K -- passes --> L[Proceed to step execution]
    K -- fails --> M[Exit with friendly error message]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/cli/src/steps/platforms/select.ts:14-22
**Schema filter reports only the first unavailable platform**

`values.find` stops at the first unavailable entry, so when a config specifies e.g. `["desktop", "mobile"]`, the schema decode error only surfaces `"Desktop isn't available yet."` — the mobile rejection is invisible until the user corrects desktop and re-runs. The interactive path (line 62–63) already loops over all `unavailable` items and emits a separate `log.warn` for each; the schema error message should be consistent by checking all entries, not just the first.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: mark roadmap choices as coming soo..."](https://github.com/ryuudotgg/forge/commit/7e4d2f881232027e69d3450c14148b0e451514b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37247960)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->