### PR TITLE
feat(bun): trust native build scripts

### DIFF
--- a/packages/generators/src/index.ts
+++ b/packages/generators/src/index.ts
@@ -97,6 +97,7 @@ export { default as tailwind } from "./style/tailwind";
 export { default as gitignore } from "./tooling/gitignore";
 export { default as typescript } from "./tooling/typescript";
 export { default as ui } from "./ui";
+export { default as bun } from "./workspace/bun";
 export { default as pnpm } from "./workspace/pnpm";
 export { default as root } from "./workspace/root";
 export { default as yarn } from "./workspace/yarn";

--- a/packages/generators/src/registry/first-party.ts
+++ b/packages/generators/src/registry/first-party.ts
@@ -19,6 +19,7 @@ import lefthook, { lefthookMetadata } from "../tooling/lefthook";
 import typescript, { typescriptMetadata } from "../tooling/typescript";
 import vscode, { vscodeMetadata } from "../tooling/vscode";
 import ui, { uiMetadata } from "../ui";
+import bun, { bunMetadata } from "../workspace/bun";
 import pnpm, { pnpmMetadata } from "../workspace/pnpm";
 import root, { rootMetadata } from "../workspace/root";
 import yarn, { yarnMetadata } from "../workspace/yarn";
@@ -36,6 +37,7 @@ export const firstPartyRegistry = defineRegistry<ForgeConfig>({
 		root,
 		pnpm,
 		yarn,
+		bun,
 		typescript,
 		biome,
 		gitignore,
@@ -59,6 +61,7 @@ export const firstPartyCatalog = [
 	addonCatalogEntry(root, rootMetadata),
 	addonCatalogEntry(pnpm, pnpmMetadata),
 	addonCatalogEntry(yarn, yarnMetadata),
+	addonCatalogEntry(bun, bunMetadata),
 	addonCatalogEntry(typescript, typescriptMetadata),
 	addonCatalogEntry(biome, biomeMetadata),
 	addonCatalogEntry(gitignore, gitignoreMetadata),

--- a/packages/generators/src/workspace/bun.ts
+++ b/packages/generators/src/workspace/bun.ts
@@ -1,0 +1,48 @@
+import { defineAddon, projectTarget, surfaceJson } from "@ryuujs/core";
+import type { ForgeConfig } from "../config";
+import { resolveDatabaseProvider } from "../data/providers";
+import type { FirstPartyAddonMetadata } from "../registry/types";
+
+const bun = defineAddon<ForgeConfig, "bun">({
+	id: "bun",
+	name: "Bun Workspace",
+	version: "0.1.0",
+	category: "packageManager",
+	exclusive: true,
+	targetMode: "single",
+	when: (config) => config.packageManager === "Bun",
+	contribute: ({ config }) => [
+		surfaceJson(projectTarget(), "rootPackageJson", {
+			trustedDependencies: trustedDependencies(config),
+		}),
+	],
+});
+
+function trustedDependencies(config: ForgeConfig): string[] {
+	const names = ["esbuild", "lefthook", "msw", "sharp"];
+
+	if (config.orm === "prisma") {
+		names.push("@prisma/engines", "prisma");
+
+		if (
+			resolveDatabaseProvider(config).prisma.clientTemplate === "better-sqlite3"
+		)
+			names.push("better-sqlite3");
+	}
+
+	return names.sort((left, right) => left.localeCompare(right));
+}
+
+export const bunMetadata = {
+	description:
+		"Configures Bun workspace behavior and trusts the build scripts managed Forge projects rely on.",
+	experimental: false,
+	hidden: false,
+	id: "bun",
+	keywords: ["bun", "package manager", "workspace"],
+	kind: "addon",
+	name: "Bun Workspace",
+	summary: "Set up Bun workspace support.",
+} as const satisfies FirstPartyAddonMetadata;
+
+export default bun;

--- a/packages/generators/tests/catalog.test.ts
+++ b/packages/generators/tests/catalog.test.ts
@@ -11,6 +11,7 @@ import {
 const visibleAddonIds = [
 	"better-auth",
 	"biome",
+	"bun",
 	"commitlint",
 	"drizzle",
 	"github-ci",

--- a/packages/generators/tests/workspace.test.ts
+++ b/packages/generators/tests/workspace.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@ryuujs/core";
 import { Effect, Layer } from "effect";
 import { describe, expect, it } from "vitest";
-import { type ForgeConfig, pnpm, root, yarn } from "../src/index";
+import { bun, type ForgeConfig, pnpm, root, yarn } from "../src/index";
 
 const commandVersions: Record<string, string> = {
 	node: "22.11.0",
@@ -311,6 +311,65 @@ describe("yarn workspace", () => {
 			"!.yarn/releases",
 			"!.yarn/sdks",
 			"!.yarn/versions",
+		]);
+	});
+});
+
+describe("bun workspace", () => {
+	it("only runs for bun projects", () => {
+		expect(bun.when({ packageManager: "Bun" })).toBe(true);
+		expect(bun.when({ packageManager: "pnpm" })).toBe(false);
+		expect(bun.when({})).toBe(false);
+	});
+
+	it("trusts the baseline build scripts", () => {
+		const packageJson = jsonSurface(
+			syncContributions(bun, { packageManager: "Bun" }),
+			"rootPackageJson",
+		);
+
+		expect(packageJson.trustedDependencies).toEqual([
+			"esbuild",
+			"lefthook",
+			"msw",
+			"sharp",
+		]);
+	});
+
+	it("trusts the prisma build scripts for the prisma orm", () => {
+		const packageJson = jsonSurface(
+			syncContributions(bun, { orm: "prisma", packageManager: "Bun" }),
+			"rootPackageJson",
+		);
+
+		expect(packageJson.trustedDependencies).toEqual([
+			"@prisma/engines",
+			"esbuild",
+			"lefthook",
+			"msw",
+			"prisma",
+			"sharp",
+		]);
+	});
+
+	it("trusts better-sqlite3 when prisma uses the local sqlite client", () => {
+		const packageJson = jsonSurface(
+			syncContributions(bun, {
+				database: "sqlite",
+				orm: "prisma",
+				packageManager: "Bun",
+			}),
+			"rootPackageJson",
+		);
+
+		expect(packageJson.trustedDependencies).toEqual([
+			"@prisma/engines",
+			"better-sqlite3",
+			"esbuild",
+			"lefthook",
+			"msw",
+			"prisma",
+			"sharp",
 		]);
 	});
 });

--- a/tests/scenarios/src/scenarios/multi-pm.test.ts
+++ b/tests/scenarios/src/scenarios/multi-pm.test.ts
@@ -21,6 +21,7 @@ interface PackageJson {
 	readonly dependencies?: Record<string, string>;
 	readonly devDependencies?: Record<string, string>;
 	readonly scripts?: Record<string, string>;
+	readonly trustedDependencies?: ReadonlyArray<string>;
 	readonly workspaces?: ReadonlyArray<string>;
 }
 
@@ -101,6 +102,7 @@ interface PrismaCell {
 	readonly migrate: string;
 	readonly pm: string;
 	readonly postinstall: string;
+	readonly trustedDependencies?: ReadonlyArray<string>;
 }
 
 const prismaCells: ReadonlyArray<PrismaCell> = [
@@ -124,6 +126,14 @@ const prismaCells: ReadonlyArray<PrismaCell> = [
 		migrate: "bun run with-env prisma migrate dev",
 		pm: "Bun",
 		postinstall: "bun --filter @acme/db generate",
+		trustedDependencies: [
+			"@prisma/engines",
+			"esbuild",
+			"lefthook",
+			"msw",
+			"prisma",
+			"sharp",
+		],
 	},
 ];
 
@@ -147,6 +157,7 @@ describe("multi-pm", () => {
 			);
 
 			expect(root.workspaces).toBeUndefined();
+			expect(root.trustedDependencies).toBeUndefined();
 			expect(workspaceYaml).toContain("catalog:");
 			expect(workspaceYaml).toMatch(/^ {2}next: \d/m);
 			expect(workspaceYaml).toContain("allowBuilds:");
@@ -284,6 +295,12 @@ describe("multi-pm", () => {
 			);
 
 			expect(root.workspaces).toEqual(["apps/*", "packages/*", "tooling/*"]);
+			expect(root.trustedDependencies).toEqual([
+				"esbuild",
+				"lefthook",
+				"msw",
+				"sharp",
+			]);
 			expect(
 				await pathExists(join(workspace.projectRoot, "pnpm-workspace.yaml")),
 			).toBe(false);
@@ -314,6 +331,7 @@ describe("multi-pm", () => {
 		migrate,
 		pm,
 		postinstall,
+		trustedDependencies,
 	}) => {
 		await withScenarioWorkspace(
 			`multi-pm-prisma-${pm.toLowerCase()}`,
@@ -336,6 +354,7 @@ describe("multi-pm", () => {
 				);
 
 				expect(root.scripts?.postinstall).toBe(postinstall);
+				expect(root.trustedDependencies).toEqual(trustedDependencies);
 				expect(db.scripts?.migrate).toBe(migrate);
 				expect(web.scripts?.["db:generate"]).toBe(dbGenerate);
 				expect(web.dependencies?.["@acme/db"]).toBe(dbDependency);


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new `bun` workspace generator that writes a `trustedDependencies` array into `rootPackageJson` for Bun-managed projects, mirroring the `allowBuilds` section that the existing `pnpm` generator emits in `pnpm-workspace.yaml`. The generator conditionally adds Prisma-specific packages (`@prisma/engines`, `prisma`, and `better-sqlite3` for SQLite) on top of the baseline set.

- **New `bun.ts` addon**: Contributes a `trustedDependencies` field to `rootPackageJson` for any project where `config.packageManager === "Bun"`, using the same package list and conditional logic as `pnpm.ts`.
- **Registry + catalog wiring**: `bun` is added to `firstPartyRegistry`, `firstPartyCatalog`, and the public `index.ts` export, consistent with the placement of `pnpm` and `yarn`.
- **Test coverage**: Unit tests in `workspace.test.ts` cover the baseline and both Prisma variants; the `multi-pm` scenario test is extended for the Bun non-Prisma and Bun+Prisma end-to-end paths.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge. It adds a self-contained new addon with no changes to existing generators.

The new `bun` addon is isolated and touches no existing code paths. Its conditional logic mirrors the battle-tested `pnpm` generator exactly. Unit tests cover all three meaningful configurations (baseline, Prisma, Prisma+SQLite) and the end-to-end scenario test validates the real generated output for both the non-Prisma and Prisma cases.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/generators/src/workspace/bun.ts | New Bun workspace addon that writes `trustedDependencies` to root `package.json`; logic faithfully mirrors the pnpm `allowBuilds` pattern with correct conditional handling for Prisma and SQLite. |
| packages/generators/src/registry/first-party.ts | Adds `bun` to the first-party registry and catalog; placement is consistent with `pnpm` and `yarn`. |
| packages/generators/src/index.ts | Exports the new `bun` generator; insertion order is consistent with the existing workspace exports. |
| packages/generators/tests/workspace.test.ts | New unit tests cover the baseline trusted-dependencies list, the Prisma variant, and the Prisma+SQLite variant; all expected arrays match the implementation logic. |
| packages/generators/tests/catalog.test.ts | Adds `"bun"` to the visible addon IDs snapshot; no issues. |
| tests/scenarios/src/scenarios/multi-pm.test.ts | Extends the Bun scenario test to assert `trustedDependencies` on the generated root package.json and adds the Bun entry to the Prisma parameterised test matrix; assertions match the implementation. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ForgeConfig] --> B{packageManager === 'Bun'?}
    B -- No --> C[bun addon skipped]
    B -- Yes --> D[trustedDependencies builder]

    D --> E[Baseline: esbuild, lefthook, msw, sharp]

    E --> F{config.orm === 'prisma'?}
    F -- No --> I[Sort with localeCompare]
    F -- Yes --> G[Add @prisma/engines + prisma]

    G --> H{resolveDatabaseProvider.prisma.clientTemplate === 'better-sqlite3'?}
    H -- No --> I
    H -- Yes --> J[Add better-sqlite3]
    J --> I

    I --> K[surfaceJson → rootPackageJson.trustedDependencies]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(bun): trust native build scripts"](https://github.com/ryuudotgg/forge/commit/0bb061c0f86043cd7eae2ddf36278bda6558745d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37258283)</sub>

<!-- /greptile_comment -->