### PR TITLE
fix: reject unparseable version output

### DIFF
--- a/packages/core/src/environment.ts
+++ b/packages/core/src/environment.ts
@@ -70,10 +70,21 @@ function detectRuntime(): { id: RuntimeId; version: string } {
 	return { id: "node", version: process.versions.node };
 }
 
+function parseMajor(version: string): number | undefined {
+	const major = version.match(/^(\d+)(?:\.|$)/)?.[1];
+	return major === undefined ? undefined : Number(major);
+}
+
 function checkCurrentRuntime(): EnvironmentCheck {
 	const { id, version } = detectRuntime();
 	const { displayName, minimumMajor } = runtimes[id];
-	const major = Number(version.split(".")[0]);
+	const major = parseMajor(version);
+
+	if (major === undefined)
+		return {
+			ok: false,
+			message: `We couldn't tell which ${displayName} version you're running.`,
+		};
 
 	if (major < minimumMajor)
 		return {
@@ -91,7 +102,13 @@ function buildPackageManagerCheck(
 	const cmd = pmCommandMap[pm];
 	const { displayName, minimumMajor } = packageManagers[cmd];
 
-	const major = Number(version.split(".")[0]);
+	const major = parseMajor(version);
+	if (major === undefined)
+		return {
+			ok: false,
+			message: `We couldn't tell which ${displayName} version you're running.`,
+		};
+
 	if (major < minimumMajor)
 		return {
 			ok: false,

--- a/packages/core/tests/environment.test.ts
+++ b/packages/core/tests/environment.test.ts
@@ -135,6 +135,38 @@ describe("environment", () => {
 		expect(result).toEqual({ ok: true, message: "pnpm v10.0.0" });
 	});
 
+	it("rejects version output it can't parse", async () => {
+		for (const garbage of ["unexpected output", "", "v.1.2", "10a.0.0"]) {
+			const result = await Effect.runPromise(
+				Environment.checkPackageManager("pnpm").pipe(
+					Effect.provide(
+						Layer.mergeAll(
+							probeLayer({ pnpm: garbage }, []),
+							Environment.Default,
+						),
+					),
+				),
+			);
+
+			expect(result).toEqual({
+				ok: false,
+				message: "We couldn't tell which pnpm version you're running.",
+			});
+		}
+	});
+
+	it("accepts a bare major version", async () => {
+		const result = await Effect.runPromise(
+			Environment.checkPackageManager("pnpm").pipe(
+				Effect.provide(
+					Layer.mergeAll(probeLayer({ pnpm: "10" }, []), Environment.Default),
+				),
+			),
+		);
+
+		expect(result).toEqual({ ok: true, message: "pnpm v10" });
+	});
+
 	it("returns a friendly missing-package-manager result on probe failure", async () => {
 		const result = await Effect.runPromise(
 			Environment.checkPackageManager("Bun").pipe(


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a dedicated `parseMajor` helper that uses a regex to extract the leading integer from a version string, returning `undefined` for inputs that cannot be parsed. Both `checkCurrentRuntime` and `buildPackageManagerCheck` are updated to use it and return a user-friendly error when parsing fails, replacing the old `Number(version.split(".")[0])` pattern that would silently propagate `NaN` and incorrectly mark garbage versions as passing.

- **`parseMajor`** uses `/^(\d+)(?:\.|$)/` to match a strictly digit-only major segment followed by either a dot or end-of-string, guarding against inputs like `"10a.0.0"` or `"v.1.2"` that the old code would have let through.
- Two new test cases cover garbage inputs (empty string, alpha-prefixed, mixed alphanumeric) and a bare major-only string (`"10"`), validating both the rejection and acceptance branches of the new helper.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted fix with no risky surface area.

The old Number(version.split(".")[0]) pattern silently produced NaN for inputs like "10a.0.0", causing the version gate to pass incorrectly because NaN < minimumMajor is always false. The new parseMajor regex correctly rejects those inputs and the fix is applied symmetrically to both the runtime and package-manager check paths. The test suite covers the full range of bad inputs as well as the bare-major edge case.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/environment.ts | Adds parseMajor helper with a regex-based parse and wires it into both version-check paths; logic is correct and handles all edge cases in the test suite. |
| packages/core/tests/environment.test.ts | Adds two new test cases covering garbage version strings and a bare major-only input; coverage is thorough for the changed code paths. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["version string"] --> B["parseMajor(version)"]
    B --> C{"/^(\\d+)(?:\\.|$)/ match?"}
    C -- "no match" --> D["return undefined"]
    C -- "matched" --> E["Number(captured group)"]
    E --> F["major: number"]

    D --> G["return { ok: false, 'couldn't tell version' }"]
    F --> H{major < minimumMajor?}
    H -- "yes" --> I["return { ok: false, 'need version X or later' }"]
    H -- "no" --> J["return { ok: true, 'DisplayName vVersion' }"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: reject unparseable version output"](https://github.com/ryuudotgg/forge/commit/bf2397ecf1e08279f2ae8decf8ca9a03fcd9f289) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37261006)</sub>

<!-- /greptile_comment -->