### PR TITLE
fix: rescue moved leaf files on apply

### DIFF
--- a/packages/core/src/apply.ts
+++ b/packages/core/src/apply.ts
@@ -30,7 +30,12 @@ function movedModuleArtifactId(
 
 	const moduleId = match?.[1];
 	const artifactPath = match?.[2];
-	if (moduleId === undefined || artifactPath !== write.path) return undefined;
+	if (
+		moduleId === undefined ||
+		artifactPath === undefined ||
+		artifactPath !== write.path
+	)
+		return undefined;
 
 	const nextRoot = current.modules[moduleId]?.root;
 	const previousRoot = previous.modules[moduleId]?.root;

--- a/packages/core/src/apply.ts
+++ b/packages/core/src/apply.ts
@@ -19,6 +19,33 @@ export interface ApplyPlan {
 	readonly writes: ReadonlyArray<PlannedWrite>;
 }
 
+function movedModuleArtifactId(
+	write: PlannedWrite,
+	current: Manifest,
+	previous: Manifest,
+): string | undefined {
+	if (write.artifactId === undefined) return undefined;
+
+	const match = /^module:([^:]+):file:(.+)$/.exec(write.artifactId);
+
+	const moduleId = match?.[1];
+	const artifactPath = match?.[2];
+	if (moduleId === undefined || artifactPath !== write.path) return undefined;
+
+	const nextRoot = current.modules[moduleId]?.root;
+	const previousRoot = previous.modules[moduleId]?.root;
+	if (
+		nextRoot === undefined ||
+		previousRoot === undefined ||
+		nextRoot === previousRoot ||
+		!write.path.startsWith(`${nextRoot}/`)
+	)
+		return undefined;
+
+	const relative = write.path.slice(nextRoot.length + 1);
+	return `module:${moduleId}:file:${previousRoot}/${relative}`;
+}
+
 export class Apply extends Effect.Service<Apply>()("Apply", {
 	accessors: true,
 	effect: Effect.gen(function* () {
@@ -49,6 +76,7 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 			plan: ApplyPlan,
 		) {
 			const previousLockfile = yield* State.readLockfile(projectRoot);
+			const previousManifest = yield* State.readManifestOrDefault(projectRoot);
 			const previousArtifactIndex = buildArtifactIndex(previousLockfile);
 			const previousArtifacts = previousArtifactIndex.byPath;
 			const previousArtifactsById = previousArtifactIndex.byId;
@@ -114,10 +142,20 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 				}
 
 				const previousArtifact = previousArtifacts.get(file.path);
+				const renamedArtifactId = movedModuleArtifactId(
+					file,
+					plan.manifest,
+					previousManifest,
+				);
+
 				const movedArtifact =
-					file.artifactId === undefined
+					(file.artifactId === undefined
 						? undefined
-						: previousArtifactsById.get(file.artifactId);
+						: previousArtifactsById.get(file.artifactId)) ??
+					(renamedArtifactId === undefined
+						? undefined
+						: previousArtifactsById.get(renamedArtifactId));
+
 				if (!previousArtifact)
 					if (!movedArtifact)
 						return yield* new ApplyError({

--- a/packages/core/tests/apply.test.ts
+++ b/packages/core/tests/apply.test.ts
@@ -546,4 +546,129 @@ describe("apply", () => {
 			expect(await pathExists(join(directory, "packages/db/src"))).toBe(true);
 		});
 	});
+
+	it("accepts a renamed module's leaf file via the previous manifest root", async () => {
+		await withTempDir("apply-renamed-leaf", async (directory) => {
+			await writeText(
+				`${directory}/packages/observability/src/logs.ts`,
+				"old-managed\n",
+			);
+
+			await Effect.runPromise(
+				State.writeManifest(directory, {
+					config: {},
+					installs: [{ definitionId: "logs", targets: [{ kind: "project" }] }],
+					modules: {
+						abcde: {
+							definitionIds: ["logs"],
+							root: "packages/telemetry",
+						},
+					},
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			await Effect.runPromise(
+				State.writeLockfile(directory, {
+					artifacts: {
+						"module:abcde:file:packages/telemetry/src/logs.ts": {
+							definitionIds: ["logs"],
+							hash: await hashContent("old-managed\n"),
+							kind: "file",
+							path: "packages/telemetry/src/logs.ts",
+						},
+					},
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			await Effect.runPromise(
+				Apply.applyPlan(directory, {
+					lockfile: { artifacts: {} },
+					manifest: {
+						config: {},
+						installs: [
+							{ definitionId: "logs", targets: [{ kind: "project" }] },
+						],
+						modules: {
+							abcde: {
+								definitionIds: ["logs"],
+								root: "packages/observability",
+							},
+						},
+					},
+					removals: [],
+					writes: [
+						{
+							artifactId:
+								"module:abcde:file:packages/observability/src/logs.ts",
+							content: "new-managed\n",
+							path: "packages/observability/src/logs.ts",
+						},
+					],
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			expect(
+				await readFile(
+					`${directory}/packages/observability/src/logs.ts`,
+					"utf-8",
+				),
+			).toBe("new-managed\n");
+		});
+	});
+
+	it("keeps rejecting unmanaged files when the module root is unchanged", async () => {
+		await withTempDir("apply-unmanaged-leaf", async (directory) => {
+			await writeText(
+				`${directory}/packages/telemetry/src/logs.ts`,
+				"old-managed\n",
+			);
+
+			await Effect.runPromise(
+				State.writeManifest(directory, {
+					config: {},
+					installs: [{ definitionId: "logs", targets: [{ kind: "project" }] }],
+					modules: {
+						abcde: {
+							definitionIds: ["logs"],
+							root: "packages/telemetry",
+						},
+					},
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			const error = await Effect.runPromise(
+				Effect.flip(
+					Apply.applyPlan(directory, {
+						lockfile: { artifacts: {} },
+						manifest: {
+							config: {},
+							installs: [
+								{ definitionId: "logs", targets: [{ kind: "project" }] },
+							],
+							modules: {
+								abcde: {
+									definitionIds: ["logs"],
+									root: "packages/telemetry",
+								},
+							},
+						},
+						removals: [],
+						writes: [
+							{
+								artifactId: "module:abcde:file:packages/telemetry/src/logs.ts",
+								content: "new-managed\n",
+								path: "packages/telemetry/src/logs.ts",
+							},
+						],
+					}).pipe(Effect.provide(coreLayer)),
+				),
+			);
+
+			expect(error).toMatchObject({
+				_tag: "ApplyError",
+				message: "Unmanaged File Exists",
+				path: "packages/telemetry/src/logs.ts",
+			});
+		});
+	});
 });

--- a/packages/core/tests/planner.test.ts
+++ b/packages/core/tests/planner.test.ts
@@ -1,4 +1,4 @@
-import { rename, rm } from "node:fs/promises";
+import { readFile, rename, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { NodeContext } from "@effect/platform-node";
 import { Cause, Effect, Exit, Layer, Option, Schema } from "effect";
@@ -31,7 +31,7 @@ import {
 	surfaceText,
 	templateModuleTarget,
 } from "../src/index";
-import { readJson, withTempDir, writeJson } from "./harness";
+import { readJson, withTempDir, writeJson, writeText } from "./harness";
 
 interface TestConfig extends Record<string, unknown> {
 	readonly audit?: boolean;
@@ -273,6 +273,37 @@ function sharedModuleRegistry() {
 		addons: [
 			telemetryAddon("logs", "client"),
 			telemetryAddon("metrics", "provider"),
+		],
+	});
+}
+
+function versionedRegistry(content: string) {
+	return defineRegistry({
+		frameworks: [],
+		templates: [],
+		addons: [
+			defineAddon<TestConfig>({
+				id: "logs",
+				name: "Logs",
+				version: "0.1.0",
+				category: "tooling",
+				exclusive: false,
+				targetMode: "single",
+				when: (config) => config.logs === true,
+				contribute: () => [
+					ensurePackageModule("telemetry", "packages/telemetry", {
+						packageType: "library",
+						template: { id: "telemetry", version: 1 },
+						capabilities: ["logs"],
+						slots: {},
+					}),
+					leafTextFile(
+						ensuredModuleTarget("telemetry"),
+						"src/logs.ts",
+						content,
+					),
+				],
+			}),
 		],
 	});
 }
@@ -982,6 +1013,105 @@ describe("planner", () => {
 				"packages/two",
 				"packages/two-moved",
 			]);
+		});
+	});
+
+	it("applies replanned leaf content after a module rename", async () => {
+		await withTempDir("planner-rename-content", async (directory) => {
+			const installs: InstallRecord[] = [
+				{ definitionId: "logs", targets: [{ kind: "project" }] },
+			];
+
+			const createPlan = await Effect.runPromise(
+				planCreateEffect(
+					directory,
+					{ logs: true },
+					versionedRegistry("export const logs = 1;\n"),
+				),
+			);
+
+			await Effect.runPromise(applyPlanEffect(directory, createPlan));
+
+			await rename(
+				join(directory, "packages/telemetry"),
+				join(directory, "packages/observability"),
+			);
+
+			const updatePlan = await Effect.runPromise(
+				planInstalledEffect(
+					directory,
+					{ logs: true },
+					installs,
+					versionedRegistry("export const logs = 2;\n"),
+				),
+			);
+
+			await Effect.runPromise(applyPlanEffect(directory, updatePlan));
+
+			expect(
+				await readFile(
+					join(directory, "packages/observability/src/logs.ts"),
+					"utf-8",
+				),
+			).toBe("export const logs = 2;\n");
+		});
+	});
+
+	it("rejects user edits to a moved managed file", async () => {
+		await withTempDir("planner-rename-edited", async (directory) => {
+			const installs: InstallRecord[] = [
+				{ definitionId: "logs", targets: [{ kind: "project" }] },
+			];
+
+			const createPlan = await Effect.runPromise(
+				planCreateEffect(
+					directory,
+					{ logs: true },
+					versionedRegistry("export const logs = 1;\n"),
+				),
+			);
+
+			await Effect.runPromise(applyPlanEffect(directory, createPlan));
+
+			await rename(
+				join(directory, "packages/telemetry"),
+				join(directory, "packages/observability"),
+			);
+			await writeText(
+				join(directory, "packages/observability/src/logs.ts"),
+				"user edit\n",
+			);
+
+			const updatePlan = await Effect.runPromise(
+				planInstalledEffect(
+					directory,
+					{ logs: true },
+					installs,
+					versionedRegistry("export const logs = 2;\n"),
+				),
+			);
+
+			const exit = await Effect.runPromiseExit(
+				applyPlanEffect(directory, updatePlan),
+			);
+
+			expect(Exit.isFailure(exit)).toBe(true);
+			if (!Exit.isFailure(exit)) throw new Error("Missing Apply Failure");
+
+			const failure = Cause.failureOption(exit.cause);
+			expect(Option.isSome(failure)).toBe(true);
+			expect(Option.getOrThrow(failure)).toMatchObject({
+				_tag: "ApplyError",
+				message: "Managed File Modified",
+				path: "packages/observability/src/logs.ts",
+			});
+
+			expect(
+				await readFile(
+					join(directory, "packages/observability/src/logs.ts"),
+					"utf-8",
+				),
+			).toBe("user edit\n");
 		});
 	});
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `applyPlan` function so it can match leaf files at their new location when a module's root directory has been renamed, preventing a spurious "Unmanaged File Exists" error that was previously raised because the old lockfile artifact was keyed under the previous root path.

- Adds `movedModuleArtifactId`, a pure helper that derives the old artifact ID by swapping the previous module root into the path when the current manifest root differs from the previous one.
- Reads `previousManifest` at the start of `applyPlan` and uses it together with the new helper as a fallback lookup in `previousArtifactsById`, preserving all existing hash-integrity checks for both the rename and the non-rename cases.
- Covers the fix with four new tests: two unit tests in `apply.test.ts` and two integration tests in `planner.test.ts`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the rename-rescue path is well-guarded and all existing hash-integrity checks remain intact.

The guard condition on line 33 relies on implicit JavaScript short-circuit behaviour to handle a null regex match rather than making the intent explicit, which is a minor readability concern with no functional impact given the current code layout.

packages/core/src/apply.ts — specifically the null-match guard in `movedModuleArtifactId`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/apply.ts | Adds `movedModuleArtifactId` helper and reads the previous manifest to derive the old lockfile artifact ID when a module root is renamed; logic and null-handling look correct for the tested scenarios. |
| packages/core/tests/apply.test.ts | Adds two unit tests covering the rename-rescue path and the unchanged-root rejection path; both exercise the new movedModuleArtifactId branching correctly. |
| packages/core/tests/planner.test.ts | Adds two integration tests (replanned content after module rename, and rejection of user edits to a moved managed file) that exercise the full plan→apply pipeline for the rename scenario. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[applyPlan called] --> B[Read previousLockfile & previousManifest]
    B --> C{For each PlannedWrite}
    C --> D{File exists on disk?}
    D -- No --> E[Queue write immediately]
    D -- Yes --> F[Hash current file content]
    F --> G{Hash matches nextHash?}
    G -- Yes --> H[Skip / no-op]
    G -- No --> I[Lookup previousArtifact by path]
    I --> J[movedModuleArtifactId\ncurrent vs previous manifest root]
    J --> K{Roots differ AND\nartifactId path matches?}
    K -- Yes --> L[Derive old artifact ID\nwith previousRoot]
    K -- No --> M[renamedArtifactId = undefined]
    L --> N[Lookup movedArtifact via\nnew OR old artifact ID]
    M --> N
    N --> O{previousArtifact\nor movedArtifact found?}
    O -- No --> P[Error: Unmanaged File Exists]
    O -- Yes --> Q{currentHash matches\nexpected hash?}
    Q -- No --> R[Error: Managed File Modified]
    Q -- Yes --> E
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/core/src/apply.ts:33
**`match` null-check is implicit but worth tracing**

`match?.[2]` is `undefined` when the regex doesn't match, so `artifactPath !== write.path` evaluates to `undefined !== someString`, which is `true` and triggers the early return. The guard works, but only because `moduleId === undefined` is checked first via short-circuit; `artifactPath` is never separately validated. Adding `|| artifactPath === undefined` would make the intent explicit and guard against future reordering of the condition.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: rescue moved leaf files on apply"](https://github.com/ryuudotgg/forge/commit/4eb0fe5a734aeeaf655b34d2fda25e7e1f4ac06d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37270224)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->