### PR TITLE
chore: keep scaffolded versions in sync

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,8 +20,10 @@
 		}
 	],
 	"packageRules": [
-		{ 
-			"groupName": "clack", "matchPackageNames": ["@clack/**"] },
+		{
+			"groupName": "clack",
+			"matchPackageNames": ["@clack/**"]
+		},
 		{
 			"groupName": "scaffolded versions",
 			"matchFileNames": ["packages/generators/src/versions.ts"]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,10 +9,22 @@
 		"platformAutomerge": true
 	},
 	"osvVulnerabilityAlerts": true,
-	"packageRules": [
+	"customManagers": [
 		{
-			"groupName": "clack",
-			"matchPackageNames": ["@clack/**"]
+			"customType": "regex",
+			"datasourceTemplate": "npm",
+			"managerFilePatterns": ["/^packages/generators/src/versions\\.ts$/"],
+			"matchStrings": [
+				"name: \"(?<depName>[^\"]+)\",\\s+version: \"(?<currentValue>[^\"]+)\""
+			]
+		}
+	],
+	"packageRules": [
+		{ 
+			"groupName": "clack", "matchPackageNames": ["@clack/**"] },
+		{
+			"groupName": "scaffolded versions",
+			"matchFileNames": ["packages/generators/src/versions.ts"]
 		}
 	],
 	"rangeStrategy": "bump",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,7 +60,7 @@
 		"picocolors": "catalog:node"
 	},
 	"devDependencies": {
-		"@effect/language-service": "^0.86.2",
+		"@effect/language-service": "catalog:effect",
 		"@ryuujs/tsconfig": "workspace:*",
 		"@types/node": "catalog:dev",
 		"@vitest/coverage-v8": "catalog:dev",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,7 @@
 		"effect": "catalog:effect"
 	},
 	"devDependencies": {
-		"@effect/language-service": "^0.86.2",
+		"@effect/language-service": "catalog:effect",
 		"@ryuujs/tsconfig": "workspace:*",
 		"@types/node": "catalog:dev",
 		"@vitest/coverage-v8": "catalog:dev",

--- a/packages/generators/src/versions.ts
+++ b/packages/generators/src/versions.ts
@@ -17,26 +17,26 @@ export interface CatalogEntry {
 }
 
 export const versions = {
-	biome: { name: "@biomejs/biome", version: "^2.4.11", group: "Tooling" },
+	biome: { name: "@biomejs/biome", version: "^2.4.16", group: "Tooling" },
 	commitlintCli: {
 		name: "@commitlint/cli",
-		version: "^20.1.0",
+		version: "^21.0.2",
 		group: "Tooling",
 	},
 	commitlintConfigConventional: {
 		name: "@commitlint/config-conventional",
-		version: "^20.0.0",
+		version: "^21.0.2",
 		group: "Tooling",
 	},
 	commitlintTypes: {
 		name: "@commitlint/types",
-		version: "^20.0.0",
+		version: "^21.0.1",
 		group: "Tooling",
 	},
-	lefthook: { name: "lefthook", version: "^2.0.0", group: "Tooling" },
+	lefthook: { name: "lefthook", version: "^2.1.9", group: "Tooling" },
 	sherif: { name: "sherif", version: "^1.11.1", group: "Tooling" },
-	turbo: { name: "turbo", version: "^2.9.6", group: "Tooling" },
-	typescript: { name: "typescript", version: "^6.0.2", group: "Tooling" },
+	turbo: { name: "turbo", version: "^2.9.18", group: "Tooling" },
+	typescript: { name: "typescript", version: "^6.0.3", group: "Tooling" },
 	typescriptNativePreview: {
 		name: "@typescript/native-preview",
 		version: "^7.0.0-dev.20260414.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ catalogs:
       specifier: 4.1.8
       version: 4.1.8
   effect:
+    '@effect/language-service':
+      specifier: ^0.86.2
+      version: 0.86.2
     '@effect/platform':
       specifier: ^0.96.1
       version: 0.96.1
@@ -117,7 +120,7 @@ importers:
         version: 1.1.1
     devDependencies:
       '@effect/language-service':
-        specifier: ^0.86.2
+        specifier: catalog:effect
         version: 0.86.2
       '@ryuujs/tsconfig':
         specifier: workspace:*
@@ -148,7 +151,7 @@ importers:
         version: 3.21.3
     devDependencies:
       '@effect/language-service':
-        specifier: ^0.86.2
+        specifier: catalog:effect
         version: 0.86.2
       '@ryuujs/tsconfig':
         specifier: workspace:*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,6 +48,7 @@ catalogs:
     effect: ^3.21.3
     "@effect/platform": ^0.96.1
     "@effect/platform-node": ^0.107.0
+    "@effect/language-service": ^0.86.2
 
 nodeLinker: hoisted
 linkWorkspacePackages: true


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps scaffolded dependency versions in sync with their latest releases and consolidates `@effect/language-service` into the shared `effect` pnpm catalog. It also wires up a Renovate regex custom manager so future version bumps in `versions.ts` can be automated via PRs.

- **Catalog consolidation**: `@effect/language-service` is moved from inline `^0.86.2` specifiers in `packages/cli` and `packages/core` into `pnpm-workspace.yaml`'s `effect` catalog, keeping all Effect-ecosystem pins in one place.
- **Scaffold version bumps**: `@biomejs/biome`, `@commitlint/{cli,config-conventional,types}`, `lefthook`, `turbo`, and `typescript` are bumped to their latest semver-compatible releases in `versions.ts`.
- **Renovate automation**: A new `customManagers` regex entry targets `versions.ts` so Renovate will open PRs when any scaffolded package has a new release, grouped under `"scaffolded versions"`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the changes are mechanical version bumps and a catalog consolidation with no logic changes.

All functional changes are straightforward: version strings updated in `versions.ts`, `@effect/language-service` moved to the shared catalog, and a Renovate custom manager added. The only notable item is a minor formatting inconsistency in the reformatted `clack` rule in `renovate.json`.

`.github/renovate.json` — the `clack` rule formatting changed inconsistently relative to the rest of the file.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/renovate.json | Adds a regex custom manager to track npm versions in `versions.ts` automatically, and a new "scaffolded versions" grouping rule; minor formatting inconsistency introduced in the reformatted `clack` rule. |
| packages/generators/src/versions.ts | Bumps `@biomejs/biome`, `@commitlint/*`, `lefthook`, `turbo`, and `typescript` scaffold versions; no logic changes. |
| packages/cli/package.json | Moves `@effect/language-service` from an inline `^0.86.2` specifier to `catalog:effect`; clean refactor. |
| packages/core/package.json | Same `@effect/language-service` catalog migration as `packages/cli/package.json`. |
| pnpm-workspace.yaml | Adds `@effect/language-service: ^0.86.2` to the `effect` catalog, backing the migration in `packages/cli` and `packages/core`. |
| pnpm-lock.yaml | Lockfile updated to reflect the new catalog entry for `@effect/language-service` and catalog specifier changes; resolved version remains `0.86.2`. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    RenovateBot["Renovate Bot"] -->|"reads regex pattern"| VersionsTs["packages/generators/src/versions.ts"]
    VersionsTs -->|"name + version fields"| CustomManager["Custom Regex Manager\n(datasource: npm)"]
    CustomManager -->|"checks npm registry"| NpmRegistry["npm Registry"]
    NpmRegistry -->|"newer version found"| PackageRule["packageRule:\ngroup: scaffolded versions"]
    PackageRule -->|"opens grouped PR"| GithubPR["GitHub PR\n(auto-assigned to ryuudotgg)"]

    PnpmWorkspace["pnpm-workspace.yaml\n(effect catalog)"] -->|"catalog:effect"| CLI["packages/cli/package.json"]
    PnpmWorkspace -->|"catalog:effect"| Core["packages/core/package.json"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/renovate.json:23-24
**Inconsistent formatting for `clack` rule**

The existing `clack` rule was reformatted to a hybrid inline style (opening `{` on one line, properties crammed onto the next, inline closing `}`) while the new `"scaffolded versions"` rule below uses the standard multi-line style. The trailing space after `{` on line 23 and the inline `}` on line 24 are inconsistent with the rest of the file and with the rule immediately following it.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: keep scaffolded versions in sync"](https://github.com/ryuudotgg/forge/commit/5ade65ada70452c746d599f98814543fa089ebf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37285873)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->