### PR TITLE
test: pin the apply rename rescue guards

### DIFF
--- a/packages/core/tests/apply.test.ts
+++ b/packages/core/tests/apply.test.ts
@@ -671,4 +671,278 @@ describe("apply", () => {
 			});
 		});
 	});
+
+	it("refuses a modified leaf file under a renamed module root", async () => {
+		await withTempDir("apply-renamed-modified", async (directory) => {
+			await writeText(
+				`${directory}/packages/observability/src/logs.ts`,
+				"user-tweak\n",
+			);
+
+			await Effect.runPromise(
+				State.writeManifest(directory, {
+					config: {},
+					installs: [{ definitionId: "logs", targets: [{ kind: "project" }] }],
+					modules: {
+						abcde: {
+							definitionIds: ["logs"],
+							root: "packages/telemetry",
+						},
+					},
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			await Effect.runPromise(
+				State.writeLockfile(directory, {
+					artifacts: {
+						"module:abcde:file:packages/telemetry/src/logs.ts": {
+							definitionIds: ["logs"],
+							hash: await hashContent("old-managed\n"),
+							kind: "file",
+							path: "packages/telemetry/src/logs.ts",
+						},
+					},
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			const error = await Effect.runPromise(
+				Effect.flip(
+					Apply.applyPlan(directory, {
+						lockfile: { artifacts: {} },
+						manifest: {
+							config: {},
+							installs: [
+								{ definitionId: "logs", targets: [{ kind: "project" }] },
+							],
+							modules: {
+								abcde: {
+									definitionIds: ["logs"],
+									root: "packages/observability",
+								},
+							},
+						},
+						removals: [],
+						writes: [
+							{
+								artifactId:
+									"module:abcde:file:packages/observability/src/logs.ts",
+								content: "new-managed\n",
+								path: "packages/observability/src/logs.ts",
+							},
+						],
+					}).pipe(Effect.provide(coreLayer)),
+				),
+			);
+
+			expect(error).toMatchObject({
+				_tag: "ApplyError",
+				message: "Managed File Modified",
+				path: "packages/observability/src/logs.ts",
+			});
+		});
+	});
+
+	it("does not rescue a leaf file outside the renamed module root", async () => {
+		await withTempDir("apply-renamed-outside", async (directory) => {
+			await writeText(
+				`${directory}/packages/elsewhere/logs.ts`,
+				"old-managed\n",
+			);
+
+			await Effect.runPromise(
+				State.writeManifest(directory, {
+					config: {},
+					installs: [{ definitionId: "logs", targets: [{ kind: "project" }] }],
+					modules: {
+						abcde: {
+							definitionIds: ["logs"],
+							root: "packages/telemetry",
+						},
+					},
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			await Effect.runPromise(
+				State.writeLockfile(directory, {
+					artifacts: {
+						"module:abcde:file:packages/telemetry/src/logs.ts": {
+							definitionIds: ["logs"],
+							hash: await hashContent("old-managed\n"),
+							kind: "file",
+							path: "packages/telemetry/src/logs.ts",
+						},
+					},
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			const error = await Effect.runPromise(
+				Effect.flip(
+					Apply.applyPlan(directory, {
+						lockfile: { artifacts: {} },
+						manifest: {
+							config: {},
+							installs: [
+								{ definitionId: "logs", targets: [{ kind: "project" }] },
+							],
+							modules: {
+								abcde: {
+									definitionIds: ["logs"],
+									root: "packages/observability",
+								},
+							},
+						},
+						removals: [],
+						writes: [
+							{
+								artifactId: "module:abcde:file:packages/elsewhere/logs.ts",
+								content: "new-managed\n",
+								path: "packages/elsewhere/logs.ts",
+							},
+						],
+					}).pipe(Effect.provide(coreLayer)),
+				),
+			);
+
+			expect(error).toMatchObject({
+				_tag: "ApplyError",
+				message: "Unmanaged File Exists",
+				path: "packages/elsewhere/logs.ts",
+			});
+		});
+	});
+
+	it("does not rescue when the previous manifest lacks the module", async () => {
+		await withTempDir("apply-renamed-no-prev", async (directory) => {
+			await writeText(
+				`${directory}/packages/observability/src/logs.ts`,
+				"old-managed\n",
+			);
+
+			await Effect.runPromise(
+				State.writeManifest(directory, {
+					config: {},
+					installs: [{ definitionId: "logs", targets: [{ kind: "project" }] }],
+					modules: {},
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			await Effect.runPromise(
+				State.writeLockfile(directory, {
+					artifacts: {
+						"module:abcde:file:packages/telemetry/src/logs.ts": {
+							definitionIds: ["logs"],
+							hash: await hashContent("old-managed\n"),
+							kind: "file",
+							path: "packages/telemetry/src/logs.ts",
+						},
+					},
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			const error = await Effect.runPromise(
+				Effect.flip(
+					Apply.applyPlan(directory, {
+						lockfile: { artifacts: {} },
+						manifest: {
+							config: {},
+							installs: [
+								{ definitionId: "logs", targets: [{ kind: "project" }] },
+							],
+							modules: {
+								abcde: {
+									definitionIds: ["logs"],
+									root: "packages/observability",
+								},
+							},
+						},
+						removals: [],
+						writes: [
+							{
+								artifactId:
+									"module:abcde:file:packages/observability/src/logs.ts",
+								content: "new-managed\n",
+								path: "packages/observability/src/logs.ts",
+							},
+						],
+					}).pipe(Effect.provide(coreLayer)),
+				),
+			);
+
+			expect(error).toMatchObject({
+				_tag: "ApplyError",
+				message: "Unmanaged File Exists",
+				path: "packages/observability/src/logs.ts",
+			});
+		});
+	});
+
+	it("does not rescue when the artifact id disagrees with the write path", async () => {
+		await withTempDir("apply-renamed-id-mismatch", async (directory) => {
+			await writeText(
+				`${directory}/packages/observability/src/logs.ts`,
+				"old-managed\n",
+			);
+
+			await Effect.runPromise(
+				State.writeManifest(directory, {
+					config: {},
+					installs: [{ definitionId: "logs", targets: [{ kind: "project" }] }],
+					modules: {
+						abcde: {
+							definitionIds: ["logs"],
+							root: "packages/telemetry",
+						},
+					},
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			await Effect.runPromise(
+				State.writeLockfile(directory, {
+					artifacts: {
+						"module:abcde:file:packages/telemetry/src/logs.ts": {
+							definitionIds: ["logs"],
+							hash: await hashContent("old-managed\n"),
+							kind: "file",
+							path: "packages/telemetry/src/logs.ts",
+						},
+					},
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			const error = await Effect.runPromise(
+				Effect.flip(
+					Apply.applyPlan(directory, {
+						lockfile: { artifacts: {} },
+						manifest: {
+							config: {},
+							installs: [
+								{ definitionId: "logs", targets: [{ kind: "project" }] },
+							],
+							modules: {
+								abcde: {
+									definitionIds: ["logs"],
+									root: "packages/observability",
+								},
+							},
+						},
+						removals: [],
+						writes: [
+							{
+								artifactId:
+									"module:abcde:file:packages/observability/src/other.ts",
+								content: "new-managed\n",
+								path: "packages/observability/src/logs.ts",
+							},
+						],
+					}).pipe(Effect.provide(coreLayer)),
+				),
+			);
+
+			expect(error).toMatchObject({
+				_tag: "ApplyError",
+				message: "Unmanaged File Exists",
+				path: "packages/observability/src/logs.ts",
+			});
+		});
+	});
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pins four boundary tests for the "rename rescue" guard introduced in `apply.ts` — the logic that allows `applyPlan` to safely overwrite a file whose module root has been renamed. The new tests exercise the four negative paths: a user-modified file under the renamed root, a file whose path falls outside the renamed root, a plan where the previous manifest has no record of the module, and a plan where the artifact ID does not agree with the actual write path.

- **Modified-file guard** (`apply-renamed-modified`): disk file carries `"user-tweak\n"`, old lockfile hash is for `"old-managed\n"` — expects `Managed File Modified`.
- **Outside-root guard** (`apply-renamed-outside`): write path `packages/elsewhere/logs.ts` does not start with the new module root `packages/observability/` — expects `Unmanaged File Exists`.
- **No-previous-module guard** (`apply-renamed-no-prev`) and **artifact-ID/path mismatch guard** (`apply-renamed-id-mismatch`): both expect `Unmanaged File Exists` when the rescue preconditions are not met.

<h3>Confidence Score: 5/5</h3>

Pure test additions with no changes to production code — safe to merge.

Each new test correctly sets up disk state, a previous lockfile/manifest, and a plan, then traces through the rename-rescue path in apply.ts to the expected error. The assertions match the actual conditional branches in movedModuleArtifactId and the surrounding guard logic. No production code is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/tests/apply.test.ts | Adds four guard tests for the rename rescue logic: modified file under renamed root (Managed File Modified), file outside renamed root (Unmanaged File Exists), no previous module entry (Unmanaged File Exists), and artifact-ID/path mismatch (Unmanaged File Exists). All setups trace correctly through the movedModuleArtifactId logic in apply.ts. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[applyPlan: file exists on disk] --> B{currentHash == nextHash?}
    B -- yes --> C[skip / no-op]
    B -- no --> D{forge.json?}
    D -- yes --> W[queue write]
    D -- no --> E{previousArtifact in byPath?}
    E -- yes --> F{currentHash == previousArtifact.hash?}
    E -- no --> G[movedModuleArtifactId]
    G --> H{artifactId path == write path AND module root changed AND path under new root?}
    H -- no --> I{movedArtifact via byId?}
    H -- yes --> J[renamedArtifactId lookup in byId]
    J --> K{found?}
    K -- no --> I
    I -- no --> ERR1[ApplyError: Unmanaged File Exists - Test 2 / Test 3 / Test 4]
    K -- yes --> L{currentHash == movedArtifact.hash?}
    F -- yes --> W
    F -- no --> ERR2[ApplyError: Managed File Modified]
    L -- yes --> W
    L -- no --> ERR3[ApplyError: Managed File Modified - Test 1]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test: pin the apply rename rescue guards"](https://github.com/ryuudotgg/forge/commit/c9c414e918b90dbf9e115e00bbfd9653098c6527) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37290368)</sub>

<!-- /greptile_comment -->