### PR TITLE
test: source catalog versions from versions.ts

### DIFF
--- a/packages/generators/tests/versions.test.ts
+++ b/packages/generators/tests/versions.test.ts
@@ -47,11 +47,12 @@ describe("catalogEntries", () => {
 });
 
 describe("catalogRef", () => {
-	it("returns the pinned name and version with an empty catalog", () => {
-		expect(catalogRef("next")).toEqual({
-			name: "next",
-			version: versions.next.version,
-			catalog: "",
-		});
+	it("maps the key to its entry name and version with an empty catalog", () => {
+		const ref = catalogRef("next");
+
+		expect(ref.name).toBe("next");
+		expect(ref.version).toBe(versions.next.version);
+		expect(ref.version).not.toBe(ref.name);
+		expect(ref.catalog).toBe("");
 	});
 });

--- a/packages/generators/tests/versions.test.ts
+++ b/packages/generators/tests/versions.test.ts
@@ -50,7 +50,7 @@ describe("catalogRef", () => {
 	it("returns the pinned name and version with an empty catalog", () => {
 		expect(catalogRef("next")).toEqual({
 			name: "next",
-			version: "16.2.3",
+			version: versions.next.version,
 			catalog: "",
 		});
 	});

--- a/packages/generators/tests/workspace.test.ts
+++ b/packages/generators/tests/workspace.test.ts
@@ -226,7 +226,9 @@ describe("pnpm workspace", () => {
 		expect(yaml).toContain(
 			'packages:\n  - "apps/*"\n  - "packages/*"\n  - "tooling/*"\n',
 		);
-		expect(yaml).toContain('  "@tanstack/react-query": ^5.90.5');
+		expect(yaml).toContain(
+			`  "@tanstack/react-query": ${versions.tanstackReactQuery.version}`,
+		);
 		expect(yaml).toContain(`  next: ${versions.next.version}`);
 		expect(yaml).not.toContain('"next"');
 	});

--- a/packages/generators/tests/workspace.test.ts
+++ b/packages/generators/tests/workspace.test.ts
@@ -9,6 +9,7 @@ import {
 import { Effect, Layer } from "effect";
 import { describe, expect, it } from "vitest";
 import { bun, type ForgeConfig, pnpm, root, yarn } from "../src/index";
+import { versions } from "../src/versions";
 
 const commandVersions: Record<string, string> = {
 	node: "22.11.0",
@@ -226,7 +227,7 @@ describe("pnpm workspace", () => {
 			'packages:\n  - "apps/*"\n  - "packages/*"\n  - "tooling/*"\n',
 		);
 		expect(yaml).toContain('  "@tanstack/react-query": ^5.90.5');
-		expect(yaml).toContain("  next: 16.2.3");
+		expect(yaml).toContain(`  next: ${versions.next.version}`);
 		expect(yaml).not.toContain('"next"');
 	});
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces two hardcoded `"16.2.3"` strings in the test suite with dynamic references to `versions.next.version`, so tests stay green when the pinned version in `versions.ts` is bumped.

- `versions.test.ts`: The `catalogRef("next")` assertion now reads the expected version from the same `versions` object the function under test uses internally, making the `version` field check tautological.
- `workspace.test.ts`: Adds a `versions` import and switches the YAML containment check to a template literal, but leaves the adjacent `@tanstack/react-query` version hardcoded on the line above.

<h3>Confidence Score: 4/5</h3>

Safe to merge — changes are test-only and do not touch production code.

Both changes are in test files with no runtime impact. The `catalogRef` version assertion is now tautological (it compares the function's output against the exact source it reads from), which weakens that particular guard. The workspace test also leaves `@tanstack/react-query` hardcoded while updating `next`, creating an inconsistency that will resurface on the next version bump.

packages/generators/tests/versions.test.ts (tautological version assertion) and packages/generators/tests/workspace.test.ts (remaining hardcoded @tanstack/react-query version).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/generators/tests/versions.test.ts | Replaces the hardcoded "16.2.3" expected value in the catalogRef test with `versions.next.version`; the version assertion is now tautological since `catalogRef` reads from the same source, but shape and `catalog: ""` checks still provide value. |
| packages/generators/tests/workspace.test.ts | Imports `versions` and replaces the hardcoded "16.2.3" YAML assertion with a template literal; the adjacent `@tanstack/react-query` assertion on line 229 remains hardcoded, creating an inconsistency within the same test. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[versions.ts\nsingle source of truth] --> B[catalogRef / catalogEntries]
    A --> C[versions.test.ts\nversions.next.version]
    A --> D[workspace.test.ts\nversions.next.version]
    B --> E[pnpm-workspace.yaml output]
    D -->|asserts output contains| E
    F[hardcoded '^5.90.5'] -->|still in workspace.test.ts line 229| D
    style F fill:#f9c,stroke:#c66
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/generators/tests/workspace.test.ts:229-230
The `next` version assertion was updated to source from `versions`, but the adjacent `@tanstack/react-query` assertion on the same line is still hardcoded. If `tanstackReactQuery.version` is ever bumped in `versions.ts`, this test will silently diverge and break without a clear pointer to the cause.

```suggestion
		expect(yaml).toContain(`  "@tanstack/react-query": ${versions.tanstackReactQuery.version}`);
		expect(yaml).toContain(`  next: ${versions.next.version}`);
```

### Issue 2 of 2
packages/generators/tests/versions.test.ts:50-56
**Tautological version assertion**

After this change the `version` check in the `catalogRef` test reduces to `versions.next.version === versions.next.version` — always true — because `catalogRef` internally returns `versions[key].version` directly. The assertion no longer catches a bug where `catalogRef` accidentally maps to the wrong field (e.g. `name` instead of `version`). The hardcoded literal `"16.2.3"` was actually a stronger guard here; if you want to decouple from the pinned value, at minimum test against a constant rather than the live source.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: source catalog versions from versi..."](https://github.com/ryuudotgg/forge/commit/908a3f532773059eb36ee70b1a3811fd7e9cdcab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37396054)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->