### PR TITLE
feat: support drizzle 1.0 rc in scaffold templates

### DIFF
--- a/packages/generators/templates/orm/drizzle/packages/db/drizzle.config.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/drizzle.config.ts
@@ -7,6 +7,4 @@ export default defineConfig({
 
   schema: "./src/schema/index.ts",
   out: "./src/drizzle",
-
-  casing: "snake_case",
 });

--- a/packages/generators/templates/orm/drizzle/packages/db/src/client.libsql.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/client.libsql.ts
@@ -1,9 +1,7 @@
 import { env } from "@__SLUG__/db/env";
 import { relations } from "@__SLUG__/db/relations";
-import * as schema from "@__SLUG__/db/schema";
 import { createClient } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 
 const client = createClient({ url: env.DATABASE_URL });
-
-export const db = drizzle({ client, schema, relations, casing: "snake_case" });
+export const db = drizzle({ client, relations });

--- a/packages/generators/templates/orm/drizzle/packages/db/src/client.mysql2.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/client.mysql2.ts
@@ -1,15 +1,7 @@
 import { env } from "@__SLUG__/db/env";
 import { relations } from "@__SLUG__/db/relations";
-import * as schema from "@__SLUG__/db/schema";
 import { drizzle } from "drizzle-orm/mysql2";
 import { createPool } from "mysql2/promise";
 
 const client = createPool({ uri: env.DATABASE_URL, timezone: "Z" });
-
-export const db = drizzle({
-  client,
-  schema,
-  relations,
-  casing: "snake_case",
-  mode: "default",
-});
+export const db = drizzle({ client, relations, mode: "default" });

--- a/packages/generators/templates/orm/drizzle/packages/db/src/client.neon-http.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/client.neon-http.ts
@@ -1,9 +1,7 @@
 import { env } from "@__SLUG__/db/env";
 import { relations } from "@__SLUG__/db/relations";
-import * as schema from "@__SLUG__/db/schema";
 import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 
 const client = neon(env.DATABASE_URL);
-
-export const db = drizzle({ client, schema, relations, casing: "snake_case" });
+export const db = drizzle({ client, relations });

--- a/packages/generators/templates/orm/drizzle/packages/db/src/client.node-postgres.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/client.node-postgres.ts
@@ -1,9 +1,7 @@
 import { env } from "@__SLUG__/db/env";
 import { relations } from "@__SLUG__/db/relations";
-import * as schema from "@__SLUG__/db/schema";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 
 const client = new Pool({ connectionString: env.DATABASE_URL });
-
-export const db = drizzle({ client, schema, relations, casing: "snake_case" });
+export const db = drizzle({ client, relations });

--- a/packages/generators/templates/orm/drizzle/packages/db/src/client.planetscale-serverless.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/client.planetscale-serverless.ts
@@ -1,8 +1,7 @@
 import { env } from "@__SLUG__/db/env";
 import { relations } from "@__SLUG__/db/relations";
-import * as schema from "@__SLUG__/db/schema";
 import { Client } from "@planetscale/database";
 import { drizzle } from "drizzle-orm/planetscale-serverless";
 
 const client = new Client({ url: env.DATABASE_URL });
-export const db = drizzle({ client, schema, relations, casing: "snake_case" });
+export const db = drizzle({ client, relations });

--- a/packages/generators/templates/orm/drizzle/packages/db/src/client.planetscale.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/client.planetscale.ts
@@ -1,6 +1,5 @@
 import { env } from "@__SLUG__/db/env";
 import { relations } from "@__SLUG__/db/relations";
-import * as schema from "@__SLUG__/db/schema";
 import { neon, neonConfig } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 
@@ -8,4 +7,4 @@ import { drizzle } from "drizzle-orm/neon-http";
 neonConfig.fetchEndpoint = (host) => `https://${host}/sql`;
 const client = neon(env.DATABASE_URL);
 
-export const db = drizzle({ client, schema, relations, casing: "snake_case" });
+export const db = drizzle({ client, relations });

--- a/packages/generators/templates/orm/drizzle/packages/db/src/client.postgres-js.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/client.postgres-js.ts
@@ -1,10 +1,8 @@
 import { env } from "@__SLUG__/db/env";
 import { relations } from "@__SLUG__/db/relations";
-import * as schema from "@__SLUG__/db/schema";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
 // Prepared statements are not supported in the pooler's transaction mode.
 const client = postgres(env.DATABASE_URL, { prepare: false });
-
-export const db = drizzle({ client, schema, relations, casing: "snake_case" });
+export const db = drizzle({ client, relations });

--- a/packages/generators/templates/orm/drizzle/packages/db/src/client.turso.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/client.turso.ts
@@ -1,6 +1,5 @@
 import { env } from "@__SLUG__/db/env";
 import { relations } from "@__SLUG__/db/relations";
-import * as schema from "@__SLUG__/db/schema";
 import { createClient } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 
@@ -9,4 +8,4 @@ const client = createClient({
   authToken: env.TURSO_AUTH_TOKEN,
 });
 
-export const db = drizzle({ client, schema, relations, casing: "snake_case" });
+export const db = drizzle({ client, relations });

--- a/packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.mysql.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.mysql.ts
@@ -1,8 +1,8 @@
-import { mysqlTable, text, timestamp, varchar } from "drizzle-orm/mysql-core";
+import { snakeCase, text, timestamp, varchar } from "drizzle-orm/mysql-core";
 
 import { users } from "./users";
 
-export const sessions = mysqlTable("sessions", {
+export const sessions = snakeCase.table("sessions", {
   id: varchar({ length: 36 }).primaryKey(),
   userId: varchar({ length: 36 })
     .notNull()
@@ -21,7 +21,7 @@ export const sessions = mysqlTable("sessions", {
     .$onUpdate(() => new Date()),
 });
 
-export const accounts = mysqlTable("accounts", {
+export const accounts = snakeCase.table("accounts", {
   id: varchar({ length: 36 }).primaryKey(),
   userId: varchar({ length: 36 })
     .notNull()
@@ -45,7 +45,7 @@ export const accounts = mysqlTable("accounts", {
     .$onUpdate(() => new Date()),
 });
 
-export const verifications = mysqlTable("verifications", {
+export const verifications = snakeCase.table("verifications", {
   id: varchar({ length: 36 }).primaryKey(),
   identifier: varchar({ length: 255 }).notNull(),
 

--- a/packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.planetscale.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.planetscale.ts
@@ -1,8 +1,6 @@
-// PlanetScale ships without foreign key constraints by default, so the user
-// references stay unenforced and the lookup indexes are declared by hand.
-import { index, mysqlTable, text, timestamp, varchar } from "drizzle-orm/mysql-core";
+import { index, snakeCase, text, timestamp, varchar } from "drizzle-orm/mysql-core";
 
-export const sessions = mysqlTable(
+export const sessions = snakeCase.table(
   "sessions",
   {
     id: varchar({ length: 36 }).primaryKey(),
@@ -23,7 +21,7 @@ export const sessions = mysqlTable(
   (table) => [index("sessions_user_id_idx").on(table.userId)],
 );
 
-export const accounts = mysqlTable(
+export const accounts = snakeCase.table(
   "accounts",
   {
     id: varchar({ length: 36 }).primaryKey(),
@@ -49,7 +47,7 @@ export const accounts = mysqlTable(
   (table) => [index("accounts_user_id_idx").on(table.userId)],
 );
 
-export const verifications = mysqlTable("verifications", {
+export const verifications = snakeCase.table("verifications", {
   id: varchar({ length: 36 }).primaryKey(),
   identifier: varchar({ length: 255 }).notNull(),
 

--- a/packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.sqlite.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.sqlite.ts
@@ -1,11 +1,11 @@
 import { sql } from "drizzle-orm";
-import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { integer, snakeCase, text } from "drizzle-orm/sqlite-core";
 
 import { users } from "./users";
 
 const unixepochMs = sql`(cast(unixepoch('subsecond') * 1000 as integer))`;
 
-export const sessions = sqliteTable("sessions", {
+export const sessions = snakeCase.table("sessions", {
   id: text().primaryKey(),
   userId: text()
     .notNull()
@@ -24,7 +24,7 @@ export const sessions = sqliteTable("sessions", {
     .$onUpdate(() => new Date()),
 });
 
-export const accounts = sqliteTable("accounts", {
+export const accounts = snakeCase.table("accounts", {
   id: text().primaryKey(),
   userId: text()
     .notNull()
@@ -48,7 +48,7 @@ export const accounts = sqliteTable("accounts", {
     .$onUpdate(() => new Date()),
 });
 
-export const verifications = sqliteTable("verifications", {
+export const verifications = snakeCase.table("verifications", {
   id: text().primaryKey(),
   identifier: text().notNull(),
 

--- a/packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.ts
@@ -1,8 +1,8 @@
-import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { snakeCase, text, timestamp } from "drizzle-orm/pg-core";
 
 import { users } from "./users";
 
-export const sessions = pgTable("sessions", {
+export const sessions = snakeCase.table("sessions", {
   id: text().primaryKey(),
   userId: text()
     .notNull()
@@ -21,7 +21,7 @@ export const sessions = pgTable("sessions", {
     .$onUpdate(() => new Date()),
 });
 
-export const accounts = pgTable("accounts", {
+export const accounts = snakeCase.table("accounts", {
   id: text().primaryKey(),
   userId: text()
     .notNull()
@@ -45,7 +45,7 @@ export const accounts = pgTable("accounts", {
     .$onUpdate(() => new Date()),
 });
 
-export const verifications = pgTable("verifications", {
+export const verifications = snakeCase.table("verifications", {
   id: text().primaryKey(),
   identifier: text().notNull(),
 

--- a/packages/generators/templates/orm/drizzle/packages/db/src/schema/users/users.mysql.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/schema/users/users.mysql.ts
@@ -1,6 +1,6 @@
-import { boolean, mysqlTable, text, timestamp, varchar } from "drizzle-orm/mysql-core";
+import { boolean, snakeCase, text, timestamp, varchar } from "drizzle-orm/mysql-core";
 
-export const users = mysqlTable("users", {
+export const users = snakeCase.table("users", {
   id: varchar({ length: 36 }).primaryKey(),
 
   name: varchar({ length: 255 }).notNull(),

--- a/packages/generators/templates/orm/drizzle/packages/db/src/schema/users/users.sqlite.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/schema/users/users.sqlite.ts
@@ -1,9 +1,9 @@
 import { sql } from "drizzle-orm";
-import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { integer, snakeCase, text } from "drizzle-orm/sqlite-core";
 
 const unixepochMs = sql`(cast(unixepoch('subsecond') * 1000 as integer))`;
 
-export const users = sqliteTable("users", {
+export const users = snakeCase.table("users", {
   id: text().primaryKey(),
 
   name: text().notNull(),

--- a/packages/generators/templates/orm/drizzle/packages/db/src/schema/users/users.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/schema/users/users.ts
@@ -1,6 +1,6 @@
-import { boolean, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { boolean, snakeCase, text, timestamp } from "drizzle-orm/pg-core";
 
-export const users = pgTable("users", {
+export const users = snakeCase.table("users", {
   id: text().primaryKey(),
   name: text().notNull(),
   email: text().notNull().unique(),

--- a/packages/generators/tests/orm.test.ts
+++ b/packages/generators/tests/orm.test.ts
@@ -314,7 +314,7 @@ describe("drizzle addon", () => {
 		expect(paths).not.toContain("src/schema/auth.ts");
 
 		expect(leafFile(contributions, "src/schema/users/users.ts")).toContain(
-			"pgTable",
+			"snakeCase.table",
 		);
 		expect(leafFile(contributions, "src/schema/index.ts")).toBe(
 			'export * from "./users";\n',
@@ -337,7 +337,7 @@ describe("drizzle addon", () => {
 		});
 
 		expect(leafFile(contributions, "src/schema/auth.ts")).toContain(
-			'export const sessions = pgTable("sessions"',
+			'export const sessions = snakeCase.table("sessions"',
 		);
 		expect(leafFile(contributions, "src/schema/index.ts")).toBe(
 			'export * from "./auth";\nexport * from "./users";\n',
@@ -413,7 +413,7 @@ describe("drizzle addon", () => {
 		);
 
 		expect(leafFile(contributions, "src/schema/users/users.ts")).toContain(
-			"mysqlTable",
+			"snakeCase.table",
 		);
 
 		const index = leafFile(contributions, "src/index.ts");

--- a/tests/scenarios/src/scenarios/better-auth.test.ts
+++ b/tests/scenarios/src/scenarios/better-auth.test.ts
@@ -48,13 +48,13 @@ describe("better auth", () => {
 			expect(auth).not.toContain("__SLUG__");
 
 			expect(authSchema).toContain(
-				'import { pgTable, text, timestamp } from "drizzle-orm/pg-core";',
+				'import { snakeCase, text, timestamp } from "drizzle-orm/pg-core";',
 			);
 			expect(authSchema).toContain(
-				'export const sessions = pgTable("sessions"',
+				'export const sessions = snakeCase.table("sessions"',
 			);
 			expect(authSchema).toContain(
-				'export const accounts = pgTable("accounts"',
+				'export const accounts = snakeCase.table("accounts"',
 			);
 			expect(authSchema).toContain(
 				'.references(() => users.id, { onDelete: "cascade" })',

--- a/tests/scenarios/src/scenarios/database-providers.test.ts
+++ b/tests/scenarios/src/scenarios/database-providers.test.ts
@@ -66,13 +66,12 @@ describe("database providers", () => {
 			expect(db.client).toBe(
 				`import { env } from "@acme/db/env";
 import { relations } from "@acme/db/relations";
-import * as schema from "@acme/db/schema";
 import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 
 const client = neon(env.DATABASE_URL);
 
-export const db = drizzle({ client, schema, relations, casing: "snake_case" });
+export const db = drizzle({ client, relations });
 `,
 			);
 
@@ -297,7 +296,6 @@ export const db = drizzle({ client, schema, relations, casing: "snake_case" });
 			expect(db.client).toBe(
 				`import { env } from "@acme/db/env";
 import { relations } from "@acme/db/relations";
-import * as schema from "@acme/db/schema";
 import { createClient } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 
@@ -306,7 +304,7 @@ const client = createClient({
   authToken: env.TURSO_AUTH_TOKEN,
 });
 
-export const db = drizzle({ client, schema, relations, casing: "snake_case" });
+export const db = drizzle({ client, relations });
 `,
 			);
 
@@ -350,7 +348,7 @@ export const db = drizzle({ client, schema, relations, casing: "snake_case" });
 			]);
 
 			expect(users).toContain(
-				'import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";',
+				'import { integer, snakeCase, text } from "drizzle-orm/sqlite-core";',
 			);
 			expect(users).toContain(
 				'emailVerified: integer({ mode: "boolean" }).notNull().default(false),',
@@ -360,7 +358,7 @@ export const db = drizzle({ client, schema, relations, casing: "snake_case" });
 			);
 
 			expect(authSchema).toContain(
-				'export const sessions = sqliteTable("sessions", {',
+				'export const sessions = snakeCase.table("sessions", {',
 			);
 			expect(authSchema).toContain('integer({ mode: "timestamp_ms" })');
 			expect(authSchema).toContain(
@@ -456,7 +454,7 @@ export const db = drizzle({ client, schema, relations, casing: "snake_case" });
 					readText("packages/auth/src/index.ts"),
 				]);
 
-				expect(users).toContain("export const users = mysqlTable(");
+				expect(users).toContain("export const users = snakeCase.table(");
 				expect(users).toContain("id: varchar({ length: 36 }).primaryKey(),");
 				expect(users).toContain(
 					"email: varchar({ length: 255 }).notNull().unique(),",

--- a/tests/scenarios/src/scenarios/database-providers.test.ts
+++ b/tests/scenarios/src/scenarios/database-providers.test.ts
@@ -70,7 +70,6 @@ import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 
 const client = neon(env.DATABASE_URL);
-
 export const db = drizzle({ client, relations });
 `,
 			);
@@ -492,7 +491,7 @@ export const db = drizzle({ client, relations });
 			expect(db.client).toContain(
 				'const client = createPool({ uri: env.DATABASE_URL, timezone: "Z" });',
 			);
-			expect(db.client).toContain('mode: "default",');
+			expect(db.client).toContain('mode: "default"');
 
 			expect(db.index).toContain(
 				'export type { MySql2Database } from "drizzle-orm/mysql2";',


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the Drizzle scaffold templates from the pre-1.0 casing API (`casing: "snake_case"` on the `drizzle()` constructor and `drizzle.config.ts`) to the Drizzle 1.0 RC per-table casing API (`snakeCase.table()` from each dialect's core package). The `schema` import is also dropped from all client files, which is correct because in RQBv2 the schema is already embedded in the `relations` object via `defineRelations(schema, ...)`.

- **Schema files** (`auth.ts`, `auth.mysql.ts`, `auth.sqlite.ts`, `auth.planetscale.ts`, `users.ts`, `users.mysql.ts`, `users.sqlite.ts`): `pgTable`/`mysqlTable`/`sqliteTable` replaced with `snakeCase.table` imported from the respective dialect package.
- **Client files** (all 8 drivers): `import * as schema` and `casing: "snake_case"` removed; `drizzle()` now receives only `client`, `relations`, and (for MySQL) `mode`.
- **Test snapshots** updated across `orm.test.ts`, `better-auth.test.ts`, and `database-providers.test.ts` to match the new template output.

<h3>Confidence Score: 4/5</h3>

The migration is mechanically correct and tests are updated to match; the only thing to restore before merging is the deleted PlanetScale FK-constraint comment.

All client and schema template changes correctly follow the Drizzle 1.0 RC snakeCase.table() API. The relations object carries the schema through defineRelations, so dropping the explicit schema parameter from drizzle() is sound. The only loss is a documentation comment in auth.planetscale.ts that explained why FK references are absent and why manual indexes exist — without it, scaffold users will encounter an unexplained structural difference in the PlanetScale template.

packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.planetscale.ts — the FK-constraint comment should be restored

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/generators/templates/orm/drizzle/packages/db/drizzle.config.ts | Removed global `casing: "snake_case"` — correct for Drizzle 1.0 RC where casing is now declared per-table via `snakeCase.table()` |
| packages/generators/templates/orm/drizzle/packages/db/src/client.neon-http.ts | Removed `schema` import and `casing: "snake_case"` from `drizzle()` call; schema info is now carried by the `relations` object (via `defineRelations(schema, ...)` in `relations.ts`) |
| packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.ts | Switched from `pgTable` to `snakeCase.table` — correct adoption of Drizzle 1.0 RC per-table casing API |
| packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.mysql.ts | Switched from `mysqlTable` to `snakeCase.table` consistently across all three auth tables |
| packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.planetscale.ts | Switched from `mysqlTable` to `snakeCase.table`; the informative comment explaining PlanetScale's lack of FK constraints was deleted, losing context for scaffold users |
| packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.sqlite.ts | Switched from `sqliteTable` to `snakeCase.table` across all three SQLite auth tables |
| packages/generators/templates/orm/drizzle/packages/db/src/schema/users/users.ts | Replaced `pgTable` with `snakeCase.table` — clean migration to Drizzle 1.0 RC casing API |
| packages/generators/tests/orm.test.ts | Test assertions updated to check for `snakeCase.table` instead of `pgTable`/`mysqlTable` |
| tests/scenarios/src/scenarios/better-auth.test.ts | Snapshot strings updated to match new `snakeCase.table` import and usage |
| tests/scenarios/src/scenarios/database-providers.test.ts | Client and schema snapshot strings updated to remove `schema` import, `casing` option, and adopt `snakeCase.table` — consistent with template changes |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["drizzle.config.ts\n(no global casing)"] --> B["Schema files\nsnakeCase.table()"]
    B --> C["relations.ts\ndefineRelations(schema, ...)"]
    C --> D["client.*.ts\ndrizzle({ client, relations })"]
    D --> E["db export\n(RQBv2 ready)"]

    subgraph "Drizzle 1.0 RC casing"
        B1["pg-core: snakeCase.table"]
        B2["mysql-core: snakeCase.table"]
        B3["sqlite-core: snakeCase.table"]
    end
    B --> B1
    B --> B2
    B --> B3
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.planetscale.ts:1
**Deleted PlanetScale FK comment**

The diff removed the two-line comment that explained why `auth.planetscale.ts` uses manual index declarations instead of `.references()` FK constraints: PlanetScale doesn't enforce foreign keys by default. Without that note, developers scaffolding a PlanetScale project will see `userId: varchar({ length: 36 }).notNull()` with no reference hint and may not understand why referential integrity is handled differently here (or why the explicit `index("sessions_user_id_idx")` calls exist at all).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: support drizzle 1.0 rc in scaffold..."](https://github.com/ryuudotgg/forge/commit/4a565561b3ab584a08038693df5c4b31b4f5b59f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37456196)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->