### PR TITLE
refactor: share the trusted build list

### DIFF
--- a/packages/generators/src/workspace/bun.ts
+++ b/packages/generators/src/workspace/bun.ts
@@ -1,7 +1,7 @@
 import { defineAddon, projectTarget, surfaceJson } from "@ryuujs/core";
 import type { ForgeConfig } from "../config";
-import { resolveDatabaseProvider } from "../data/providers";
 import type { FirstPartyAddonMetadata } from "../registry/types";
+import { trustedBuildDependencies } from "./trusted-builds";
 
 const bun = defineAddon<ForgeConfig, "bun">({
 	id: "bun",
@@ -19,18 +19,9 @@ const bun = defineAddon<ForgeConfig, "bun">({
 });
 
 function trustedDependencies(config: ForgeConfig): string[] {
-	const names = ["esbuild", "lefthook", "msw", "sharp"];
-
-	if (config.orm === "prisma") {
-		names.push("@prisma/engines", "prisma");
-
-		if (
-			resolveDatabaseProvider(config).prisma.clientTemplate === "better-sqlite3"
-		)
-			names.push("better-sqlite3");
-	}
-
-	return names.sort((left, right) => left.localeCompare(right));
+	return trustedBuildDependencies(config).sort((left, right) =>
+		left.localeCompare(right),
+	);
 }
 
 export const bunMetadata = {

--- a/packages/generators/src/workspace/pnpm.ts
+++ b/packages/generators/src/workspace/pnpm.ts
@@ -1,8 +1,8 @@
 import { defineAddon, leafTextFile, projectTarget } from "@ryuujs/core";
 import type { ForgeConfig } from "../config";
-import { resolveDatabaseProvider } from "../data/providers";
 import type { FirstPartyAddonMetadata } from "../registry/types";
 import { catalogEntries } from "../versions";
+import { trustedBuildDependencies } from "./trusted-builds";
 
 const pnpm = defineAddon<ForgeConfig, "pnpm">({
 	id: "pnpm",
@@ -60,22 +60,9 @@ function buildWorkspaceYaml(config: ForgeConfig): string {
 	lines.push("");
 	lines.push("allowBuilds:");
 
-	if (config.orm === "prisma") {
-		lines.push(`  ${quote("@prisma/engines")}: true`);
+	for (const name of [...trustedBuildDependencies(config)].sort())
+		lines.push(`  ${quote(name)}: true`);
 
-		if (
-			resolveDatabaseProvider(config).prisma.clientTemplate === "better-sqlite3"
-		)
-			lines.push("  better-sqlite3: true");
-	}
-
-	lines.push("  esbuild: true");
-	lines.push("  lefthook: true");
-	lines.push("  msw: true");
-
-	if (config.orm === "prisma") lines.push("  prisma: true");
-
-	lines.push("  sharp: true");
 	lines.push("");
 
 	return lines.join("\n");

--- a/packages/generators/src/workspace/trusted-builds.ts
+++ b/packages/generators/src/workspace/trusted-builds.ts
@@ -1,0 +1,17 @@
+import type { ForgeConfig } from "../config";
+import { resolveDatabaseProvider } from "../data/providers";
+
+export function trustedBuildDependencies(config: ForgeConfig): string[] {
+	const names = ["esbuild", "lefthook", "msw", "sharp"];
+
+	if (config.orm === "prisma") {
+		names.push("@prisma/engines", "prisma");
+
+		if (
+			resolveDatabaseProvider(config).prisma.clientTemplate === "better-sqlite3"
+		)
+			names.push("better-sqlite3");
+	}
+
+	return names;
+}

--- a/packages/generators/tests/workspace.test.ts
+++ b/packages/generators/tests/workspace.test.ts
@@ -10,6 +10,7 @@ import { Effect, Layer } from "effect";
 import { describe, expect, it } from "vitest";
 import { bun, type ForgeConfig, pnpm, root, yarn } from "../src/index";
 import { versions } from "../src/versions";
+import { trustedBuildDependencies } from "../src/workspace/trusted-builds";
 
 const commandVersions: Record<string, string> = {
 	node: "22.11.0",
@@ -374,5 +375,46 @@ describe("bun workspace", () => {
 			"prisma",
 			"sharp",
 		]);
+	});
+});
+
+describe("trusted-builds parity", () => {
+	it("pnpm allowBuilds and bun trustedDependencies use the same set for prisma + better-sqlite3", () => {
+		const config: ForgeConfig = {
+			database: "sqlite",
+			orm: "prisma",
+			packageManager: "Bun",
+		};
+
+		const bunNames = (
+			jsonSurface(syncContributions(bun, config), "rootPackageJson")
+				.trustedDependencies as string[]
+		).sort();
+
+		const pnpmYaml = leafFile(
+			syncContributions(pnpm, { database: "sqlite", orm: "prisma" }),
+			"pnpm-workspace.yaml",
+		);
+
+		const allowBuildsStart =
+			pnpmYaml.indexOf("allowBuilds:\n") + "allowBuilds:\n".length;
+
+		const allowBuildsBlock = pnpmYaml.slice(allowBuildsStart);
+		const pnpmNames = allowBuildsBlock
+			.split("\n")
+			.filter((line) => line.startsWith("  "))
+			.map((line) =>
+				line
+					.trim()
+					.replace(/^"(.+)":\s*true$/, "$1")
+					.replace(/:\s*true$/, ""),
+			)
+			.sort();
+
+		expect(pnpmNames).toEqual(
+			trustedBuildDependencies({ database: "sqlite", orm: "prisma" }).sort(),
+		);
+		expect(bunNames).toEqual(trustedBuildDependencies(config).sort());
+		expect(pnpmNames).toEqual(bunNames);
 	});
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This refactor extracts the shared trusted-build dependency logic from `bun.ts` and `pnpm.ts` into a new `trusted-builds.ts` module, eliminating duplication of the ORM/database conditionals across both generators.

- `trustedBuildDependencies(config)` now owns all conditional branching (prisma engines, better-sqlite3) and both generators delegate sorting to their call sites.
- A new parity test in `workspace.test.ts` verifies that bun and pnpm produce the same dependency set for the prisma + sqlite configuration.

<h3>Confidence Score: 4/5</h3>

This is a mechanical extraction of duplicated logic into a shared module; the generated output for existing configurations is unchanged.

The refactor correctly consolidates two previously identical code paths. The only noteworthy gaps are a stylistic inconsistency in sort comparators between the two call sites, and a parity test that only exercises the maximal (prisma + sqlite) configuration.

workspace.test.ts could benefit from additional configuration branches; pnpm.ts uses a default sort comparator where bun.ts uses localeCompare.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/generators/src/workspace/trusted-builds.ts | New shared module extracting the trusted-build dependency list; clean extraction of logic previously duplicated between bun.ts and pnpm.ts. |
| packages/generators/src/workspace/bun.ts | Delegates to trustedBuildDependencies and sorts with localeCompare; sorts differently from pnpm.ts's default sort, which is a minor inconsistency. |
| packages/generators/src/workspace/pnpm.ts | Uses default Array.sort() (no comparator) on the result of trustedBuildDependencies; functionally equivalent to bun.ts's localeCompare sort for ASCII names, but semantically inconsistent. |
| packages/generators/tests/workspace.test.ts | Adds a parity test covering only the prisma+sqlite (better-sqlite3) configuration; non-prisma and prisma+non-sqlite paths are not explicitly covered. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ForgeConfig] --> B[trustedBuildDependencies]
    B --> C{config.orm === 'prisma'?}
    C -- No --> D["Base names\n[esbuild, lefthook, msw, sharp]"]
    C -- Yes --> E["Base + prisma names\n[..., @prisma/engines, prisma]"]
    E --> F{resolveDatabaseProvider\nclientTemplate === 'better-sqlite3'?}
    F -- No --> G[Return without better-sqlite3]
    F -- Yes --> H[Push better-sqlite3]
    H --> I[Return full list]
    D --> J[Return base list]
    B --> K[bun.ts / trustedDependencies]
    B --> L[pnpm.ts / buildWorkspaceYaml]
    K --> M["sort via localeCompare\n→ package.json trustedDependencies"]
    L --> N["sort via default .sort()\n→ pnpm-workspace.yaml allowBuilds"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/generators/src/workspace/pnpm.ts:63-64
The sort in `pnpm.ts` uses the default comparator (Unicode code-point order) while `bun.ts` sorts with `localeCompare`. For today's all-ASCII package names the two orderings are identical, but a future entry with accented or non-ASCII characters would produce different output from each generator. Aligning to `localeCompare` keeps both callers consistent.

```suggestion
	for (const name of [...trustedBuildDependencies(config)].sort((a, b) =>
		a.localeCompare(b),
	))
		lines.push(`  ${quote(name)}: true`);
```

### Issue 2 of 2
packages/generators/tests/workspace.test.ts:381-420
**Parity test covers only the prisma + sqlite configuration**

The single test case exercises the maximal set (all four base packages plus `@prisma/engines`, `prisma`, and `better-sqlite3`), but the two other meaningful branches — non-prisma configs (only the four base packages) and prisma with a non-sqlite database (no `better-sqlite3`) — are not validated. If the branching logic in `trustedBuildDependencies` drifts from what either generator renders, those gaps wouldn't be caught.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: share the trusted build list"](https://github.com/ryuudotgg/forge/commit/6ef8401df5db38451481a9feb463c55caa2e56a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37459591)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->