### PR TITLE
test: cover cli cancel and failure paths

### DIFF
--- a/packages/cli/tests/steps-post.test.ts
+++ b/packages/cli/tests/steps-post.test.ts
@@ -11,6 +11,7 @@ import { SKIP } from "../src/steps/types";
 
 const promptMocks = vi.hoisted(() => ({
 	confirm: vi.fn(),
+	isCancel: vi.fn(() => false),
 	spinner: vi.fn(),
 	spinnerStart: vi.fn(),
 	spinnerStop: vi.fn(),
@@ -21,12 +22,20 @@ const commandMocks = vi.hoisted(() => ({
 	exitCode: vi.fn(),
 }));
 
+const cancelMocks = vi.hoisted(() => ({
+	cancel: vi.fn((): never => {
+		throw new Error("Cancelled");
+	}),
+}));
+
 vi.mock("@clack/prompts", () => ({
 	confirm: promptMocks.confirm,
-	isCancel: () => false,
+	isCancel: promptMocks.isCancel,
 	spinner: promptMocks.spinner,
 	text: promptMocks.text,
 }));
+
+vi.mock("../src/utils/cancel", () => ({ cancel: cancelMocks.cancel }));
 
 vi.mock("@effect/platform", async (importOriginal) => {
 	const original = await importOriginal<typeof import("@effect/platform")>();
@@ -88,6 +97,8 @@ function lastCommitSubject(directory: string): string {
 
 beforeEach(() => {
 	promptMocks.confirm.mockReset();
+	promptMocks.isCancel.mockReset();
+	promptMocks.isCancel.mockReturnValue(false);
 	promptMocks.spinner.mockReset();
 	promptMocks.spinnerStart.mockReset();
 	promptMocks.spinnerStop.mockReset();
@@ -99,6 +110,7 @@ beforeEach(() => {
 	}));
 	commandMocks.exitCode.mockReset();
 	commandMocks.exitCode.mockReturnValue(Effect.succeed(0));
+	cancelMocks.cancel.mockClear();
 });
 
 describe("git init step", () => {
@@ -176,6 +188,40 @@ describe("git init step", () => {
 			expect(existsSync(join(directory, ".git"))).toBe(false);
 		});
 	});
+
+	it("cancels git init when the confirm prompt is interrupted", async () => {
+		await withTempDir("git-init", async (directory) => {
+			const sentinel = Symbol("cancel");
+			promptMocks.confirm.mockResolvedValue(sentinel);
+			promptMocks.isCancel.mockReturnValueOnce(true);
+
+			await expect(
+				gitInitStep.execute({ path: directory }, true),
+			).rejects.toThrow("Cancelled");
+
+			expect(cancelMocks.cancel).toHaveBeenCalledTimes(1);
+			expect(promptMocks.text).not.toHaveBeenCalled();
+		});
+	});
+
+	it("cancels git init when the message prompt is interrupted", async () => {
+		await withTempDir("git-init", async (directory) => {
+			await writeFile(join(directory, "README.md"), "# Forge\n", "utf-8");
+			const sentinel = Symbol("cancel");
+			promptMocks.confirm.mockResolvedValue(true);
+			promptMocks.text.mockResolvedValue(sentinel);
+			promptMocks.isCancel.mockReturnValueOnce(false).mockReturnValueOnce(true);
+
+			await withGitEnv(async () => {
+				await expect(
+					gitInitStep.execute({ path: directory }, true),
+				).rejects.toThrow("Cancelled");
+			});
+
+			expect(cancelMocks.cancel).toHaveBeenCalledTimes(1);
+			expect(existsSync(join(directory, ".git"))).toBe(false);
+		});
+	});
 });
 
 describe("install deps step", () => {
@@ -201,6 +247,19 @@ describe("install deps step", () => {
 			inactive: "No",
 		});
 		expect(promptMocks.spinner).not.toHaveBeenCalled();
+		expect(commandMocks.exitCode).not.toHaveBeenCalled();
+	});
+
+	it("cancels dependency installation when the prompt is interrupted", async () => {
+		const sentinel = Symbol("cancel");
+		promptMocks.confirm.mockResolvedValue(sentinel);
+		promptMocks.isCancel.mockReturnValueOnce(true);
+
+		await expect(
+			installDepsStep.execute({ path: "./project" }, true),
+		).rejects.toThrow("Cancelled");
+
+		expect(cancelMocks.cancel).toHaveBeenCalledTimes(1);
 		expect(commandMocks.exitCode).not.toHaveBeenCalled();
 	});
 

--- a/packages/cli/tests/steps-post.test.ts
+++ b/packages/cli/tests/steps-post.test.ts
@@ -206,17 +206,14 @@ describe("git init step", () => {
 
 	it("cancels git init when the message prompt is interrupted", async () => {
 		await withTempDir("git-init", async (directory) => {
-			await writeFile(join(directory, "README.md"), "# Forge\n", "utf-8");
 			const sentinel = Symbol("cancel");
 			promptMocks.confirm.mockResolvedValue(true);
 			promptMocks.text.mockResolvedValue(sentinel);
 			promptMocks.isCancel.mockReturnValueOnce(false).mockReturnValueOnce(true);
 
-			await withGitEnv(async () => {
-				await expect(
-					gitInitStep.execute({ path: directory }, true),
-				).rejects.toThrow("Cancelled");
-			});
+			await expect(
+				gitInitStep.execute({ path: directory }, true),
+			).rejects.toThrow("Cancelled");
 
 			expect(cancelMocks.cancel).toHaveBeenCalledTimes(1);
 			expect(existsSync(join(directory, ".git"))).toBe(false);


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds test coverage for the cancel and failure paths in the CLI's `git-init` and `install-deps` post-steps, converting the previously inlined `isCancel: () => false` stub into a configurable mock and introducing a hoisted `cancelMocks` that throws to simulate the `never`-returning `cancel()` utility.

- Refactors `isCancel` from a hardcoded no-op into a `vi.fn()` so individual tests can drive cancel-path branches with `mockReturnValueOnce(true)`.
- Adds three new tests covering: confirm-prompt cancellation in git-init, text-prompt cancellation in git-init (with a `.git`-absence assertion), and confirm-prompt cancellation in install-deps.
- Uses `mockClear()` (not `mockReset()`) for the cancel mock intentionally — `mockReset()` would wipe the throwing implementation, breaking subsequent tests.

<h3>Confidence Score: 5/5</h3>

Test-only change with no modifications to production code; safe to merge.

The only changed file is a test file. Mock wiring is correct, the `mockClear` vs `mockReset` distinction for the cancel mock is deliberate and sound, and the new tests accurately model the production cancel flow. One `withGitEnv` wrapper is redundant but harmless.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/tests/steps-post.test.ts | Adds cancel/failure path coverage for git-init and install-deps steps; mock setup is correct and `mockClear` vs `mockReset` usage for the cancel mock is intentional. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["gitInitStep.execute(config, interactive)"] --> B{config.gitInit === false?}
    B -- Yes --> SKIP1[return SKIP]
    B -- No --> C{interactive?}
    C -- No --> D[Effect.runPromise gitInit default message]
    D --> SKIP2[return SKIP]
    C -- Yes --> E["confirm() prompt"]
    E --> F{"isCancel(shouldInit)?"}
    F -- Yes --> G["cancel() → throws ❌"]
    F -- No --> H{"!shouldInit?"}
    H -- Yes --> SKIP3[return SKIP]
    H -- No --> I["text() prompt"]
    I --> J{"isCancel(message)?"}
    J -- Yes --> K["cancel() → throws ❌"]
    J -- No --> L["Effect.runPromise gitInit with message"]

    style G fill:#f66,color:#fff
    style K fill:#f66,color:#fff
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/cli/tests/steps-post.test.ts:215-219
**Unnecessary `withGitEnv` wrapper**

In this test the cancel mock throws before the git operations ever start — `cancel()` fires immediately after the second `isCancel` check on the text-prompt result, so no `git init`, `git add`, or `git commit` invocation is made. Wrapping the assertion in `withGitEnv` has no effect here and adds noise; the existing `withTempDir` wrapper is sufficient.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover cli cancel and failure paths"](https://github.com/ryuudotgg/forge/commit/50094eed6889898e0045136aec91fb4e95e3d13e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37466510)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->