### PR TITLE
fix(db): drop mysql drizzle mode for rc

### DIFF
--- a/packages/generators/templates/orm/drizzle/packages/db/src/client.mysql2.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/client.mysql2.ts
@@ -4,4 +4,4 @@ import { drizzle } from "drizzle-orm/mysql2";
 import { createPool } from "mysql2/promise";
 
 const client = createPool({ uri: env.DATABASE_URL, timezone: "Z" });
-export const db = drizzle({ client, relations, mode: "default" });
+export const db = drizzle({ client, relations });

--- a/tests/scenarios/src/scenarios/database-providers.test.ts
+++ b/tests/scenarios/src/scenarios/database-providers.test.ts
@@ -491,7 +491,9 @@ export const db = drizzle({ client, relations });
 			expect(db.client).toContain(
 				'const client = createPool({ uri: env.DATABASE_URL, timezone: "Z" });',
 			);
-			expect(db.client).toContain('mode: "default"');
+			expect(db.client).toContain(
+				"export const db = drizzle({ client, relations });",
+			);
 
 			expect(db.index).toContain(
 				'export type { MySql2Database } from "drizzle-orm/mysql2";',

--- a/tests/scenarios/src/scenarios/install.smoke.test.ts
+++ b/tests/scenarios/src/scenarios/install.smoke.test.ts
@@ -10,10 +10,15 @@ import {
 } from "../utils/harness";
 
 async function expectTypecheckPasses(workspace: ScenarioProject) {
-	await runCommand("pnpm", ["install"], {
+	const installResult = await runCommand("pnpm", ["install"], {
 		cwd: workspace.projectRoot,
 		env: forgeEnvironment(workspace.workspaceRoot),
 	});
+
+	expect(
+		installResult.exitCode,
+		`pnpm install failed with code ${installResult.exitCode}\n${installResult.stdout}\n${installResult.stderr}`,
+	).toBe(0);
 
 	const result = await runCommand("pnpm", ["typecheck"], {
 		cwd: workspace.projectRoot,

--- a/tests/scenarios/src/scenarios/install.smoke.test.ts
+++ b/tests/scenarios/src/scenarios/install.smoke.test.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	createProject,
+	forgeEnvironment,
 	pathExists,
 	runCommand,
 	type ScenarioProject,
@@ -9,8 +10,14 @@ import {
 } from "../utils/harness";
 
 async function expectTypecheckPasses(workspace: ScenarioProject) {
+	await runCommand("pnpm", ["install"], {
+		cwd: workspace.projectRoot,
+		env: forgeEnvironment(workspace.workspaceRoot),
+	});
+
 	const result = await runCommand("pnpm", ["typecheck"], {
 		cwd: workspace.projectRoot,
+		env: forgeEnvironment(workspace.workspaceRoot),
 	});
 
 	expect(
@@ -53,6 +60,48 @@ describe.runIf(process.env.FORGE_SMOKE === "1")("install smoke", () => {
 				{
 					authentication: "better-auth",
 					database: "postgresql",
+					linter: "biome",
+					orm: "drizzle",
+					packageManager: "pnpm",
+					rpc: "trpc",
+					style: "tailwind",
+					web: "nextjs",
+				},
+				{ install: true },
+			);
+
+			await expectTypecheckPasses(workspace);
+		});
+	}, 600_000);
+
+	it("installs and typechecks a drizzle mysql project", async () => {
+		await withScenarioWorkspace("smoke-drizzle-mysql", async (workspace) => {
+			await createProject(
+				workspace,
+				{
+					authentication: "better-auth",
+					database: "mysql",
+					linter: "biome",
+					orm: "drizzle",
+					packageManager: "pnpm",
+					rpc: "trpc",
+					style: "tailwind",
+					web: "nextjs",
+				},
+				{ install: true },
+			);
+
+			await expectTypecheckPasses(workspace);
+		});
+	}, 600_000);
+
+	it("installs and typechecks a drizzle sqlite project", async () => {
+		await withScenarioWorkspace("smoke-drizzle-sqlite", async (workspace) => {
+			await createProject(
+				workspace,
+				{
+					authentication: "better-auth",
+					database: "sqlite",
 					linter: "biome",
 					orm: "drizzle",
 					packageManager: "pnpm",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the `mode: "default"` option from the Drizzle MySQL2 client template, which is no longer accepted in the Drizzle ORM RC for standard MySQL2 connections. Tests are updated accordingly and two new smoke tests (Drizzle MySQL and SQLite) are added.

- `client.mysql2.ts`: Drops `mode: \"default\"` from `drizzle({ client, relations })`, bringing the template in line with the Drizzle ORM RC API.
- `database-providers.test.ts`: Updates the assertion to verify the new (mode-free) `drizzle(...)` call string instead of the old `mode: \"default\"` substring.
- `install.smoke.test.ts`: Adds Drizzle MySQL and SQLite smoke tests, and refactors `expectTypecheckPasses` to always run `pnpm install` (with `forgeEnvironment`) before typechecking.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the template change is a straightforward API cleanup and all three files are self-consistent.

The core template fix and its test update are clean and correct. The only rough edge is in the new smoke-test helper: `pnpm install` runs but its exit code is never checked, so a failed install would silently proceed and surface as a misleading typecheck failure rather than an install failure.

tests/scenarios/src/scenarios/install.smoke.test.ts — the unguarded `pnpm install` result in `expectTypecheckPasses`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/generators/templates/orm/drizzle/packages/db/src/client.mysql2.ts | Drops `mode: "default"` from the Drizzle MySQL2 client constructor — the option was removed in the Drizzle ORM RC for non-PlanetScale connections. |
| tests/scenarios/src/scenarios/database-providers.test.ts | Updates the mysql2 client assertion to match the new template output (no `mode` option), keeping the test in sync with the template change. |
| tests/scenarios/src/scenarios/install.smoke.test.ts | Adds smoke tests for Drizzle MySQL and SQLite and prepends a `pnpm install` step to `expectTypecheckPasses`; the install exit code is not checked, so a silent install failure would surface as a misleading typecheck error. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[expectTypecheckPasses] --> B[pnpm install\nwith forgeEnvironment]
    B --> C{exit code\nchecked?}
    C -- "No (current)" --> D[pnpm typecheck\nwith forgeEnvironment]
    C -- "Yes (suggested)" --> E{exitCode == 0?}
    E -- No --> F[Fail: install error]
    E -- Yes --> D
    D --> G{exitCode == 0?}
    G -- Yes --> H[Pass]
    G -- No --> I[Fail: typecheck error]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/scenarios/src/scenarios/install.smoke.test.ts:13-16
The result of `pnpm install` is never inspected. If the install fails the test continues and `pnpm typecheck` will fail too — but the assertion message will blame typecheck, hiding the real cause. Asserting the install exit code here (or using a throwing helper like `runForge`) makes failures easier to diagnose.

```suggestion
	const installResult = await runCommand("pnpm", ["install"], {
		cwd: workspace.projectRoot,
		env: forgeEnvironment(workspace.workspaceRoot),
	});

	expect(
		installResult.exitCode,
		`pnpm install failed with code ${installResult.exitCode}\n${installResult.stdout}\n${installResult.stderr}`,
	).toBe(0);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(db): drop mysql drizzle mode for rc"](https://github.com/ryuudotgg/forge/commit/dd5e7b712de8ae35a8d3a7d4d6ecda6ce23533ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37693416)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->