### PR TITLE
test: cover platform and auth cancel paths

### DIFF
--- a/packages/cli/tests/steps-auth.test.ts
+++ b/packages/cli/tests/steps-auth.test.ts
@@ -11,6 +11,12 @@ const promptMocks = vi.hoisted(() => ({
 	select: vi.fn(),
 }));
 
+const cancelMocks = vi.hoisted(() => ({
+	cancel: vi.fn((): never => {
+		throw new Error("Cancelled");
+	}),
+}));
+
 vi.mock("@clack/prompts", () => ({
 	cancel: promptMocks.cancel,
 	confirm: promptMocks.confirm,
@@ -18,6 +24,8 @@ vi.mock("@clack/prompts", () => ({
 	log: { warn: promptMocks.logWarn },
 	select: promptMocks.select,
 }));
+
+vi.mock("../src/utils/cancel", () => ({ cancel: cancelMocks.cancel }));
 
 function rawConfig(values: { [key: string]: unknown }): PartialConfig {
 	const config: PartialConfig = {};
@@ -120,6 +128,7 @@ describe("authenticationCustomUI step", () => {
 		promptMocks.logWarn.mockReset();
 		promptMocks.select.mockReset();
 		promptMocks.isCancel.mockReturnValue(false);
+		cancelMocks.cancel.mockClear();
 	});
 
 	it("only runs for providers with a hosted UI", () => {
@@ -164,5 +173,16 @@ describe("authenticationCustomUI step", () => {
 			active: "Yes",
 			inactive: "No",
 		});
+	});
+
+	it("cancels the custom-UI prompt when interrupted", async () => {
+		promptMocks.confirm.mockResolvedValue(Symbol("cancel"));
+		promptMocks.isCancel.mockReturnValueOnce(true);
+
+		await expect(
+			authenticationCustomUIStep.execute({ authentication: "clerk" }, true),
+		).rejects.toThrow("Cancelled");
+
+		expect(cancelMocks.cancel).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/cli/tests/steps-platforms.test.ts
+++ b/packages/cli/tests/steps-platforms.test.ts
@@ -6,17 +6,26 @@ import webStep from "../src/steps/platforms/web";
 import { type PartialConfig, SKIP } from "../src/steps/types";
 
 const promptMocks = vi.hoisted(() => ({
+	isCancel: vi.fn(() => false),
 	logWarn: vi.fn(),
 	multiselect: vi.fn(),
 	select: vi.fn(),
 }));
 
+const cancelMocks = vi.hoisted(() => ({
+	cancel: vi.fn((): never => {
+		throw new Error("Cancelled");
+	}),
+}));
+
 vi.mock("@clack/prompts", () => ({
-	isCancel: () => false,
+	isCancel: promptMocks.isCancel,
 	log: { warn: promptMocks.logWarn },
 	multiselect: promptMocks.multiselect,
 	select: promptMocks.select,
 }));
+
+vi.mock("../src/utils/cancel", () => ({ cancel: cancelMocks.cancel }));
 
 function rawConfig(entries: Record<string, unknown>): PartialConfig {
 	const config: PartialConfig = {};
@@ -27,9 +36,12 @@ function rawConfig(entries: Record<string, unknown>): PartialConfig {
 }
 
 beforeEach(() => {
+	promptMocks.isCancel.mockReset();
+	promptMocks.isCancel.mockReturnValue(false);
 	promptMocks.logWarn.mockReset();
 	promptMocks.multiselect.mockReset();
 	promptMocks.select.mockReset();
+	cancelMocks.cancel.mockClear();
 });
 
 describe("platforms step", () => {
@@ -112,6 +124,15 @@ describe("platforms step", () => {
 		promptMocks.multiselect.mockResolvedValue([]);
 
 		await expect(platformsStep.execute({}, true)).resolves.toBe(SKIP);
+	});
+
+	it("cancels platform selection when the prompt is interrupted", async () => {
+		promptMocks.multiselect.mockResolvedValue(Symbol("cancel"));
+		promptMocks.isCancel.mockReturnValueOnce(true);
+
+		await expect(platformsStep.execute({}, true)).rejects.toThrow("Cancelled");
+
+		expect(cancelMocks.cancel).toHaveBeenCalledTimes(1);
 	});
 });
 
@@ -218,6 +239,15 @@ describe("desktop step", () => {
 			],
 		});
 	});
+
+	it("cancels the desktop prompt when interrupted", async () => {
+		promptMocks.select.mockResolvedValue(Symbol("cancel"));
+		promptMocks.isCancel.mockReturnValueOnce(true);
+
+		await expect(desktopStep.execute({}, true)).rejects.toThrow("Cancelled");
+
+		expect(cancelMocks.cancel).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe("mobile step", () => {
@@ -255,5 +285,14 @@ describe("mobile step", () => {
 				{ label: "React Native", value: "react-native" },
 			],
 		});
+	});
+
+	it("cancels the mobile prompt when interrupted", async () => {
+		promptMocks.select.mockResolvedValue(Symbol("cancel"));
+		promptMocks.isCancel.mockReturnValueOnce(true);
+
+		await expect(mobileStep.execute({}, true)).rejects.toThrow("Cancelled");
+
+		expect(cancelMocks.cancel).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds cancel-path test coverage for interactive prompts across the CLI wizard steps. It upgrades `isCancel` from a static inline stub to a controllable mock in `steps-platforms.test.ts` and introduces a shared `cancelMocks` fixture (using `mockClear` to preserve the throwing implementation between tests) in both test files.

- Adds cancel tests for `platformsStep` (multiselect), `desktopStep` (select), `mobileStep` (select), and `authenticationCustomUIStep` (confirm), each verifying that `cancel()` is called exactly once and the returned promise rejects with `\"Cancelled\"`.
- Refactors the `isCancel` mock in `steps-platforms.test.ts` to be individually resettable via `mockReturnValue`/`mockReturnValueOnce`, replacing the previous static `() => false` inline factory.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all new tests correctly exercise the cancel path and the mock refactoring is backward-compatible.

The `webStep` in `src/steps/platforms/web.ts` has an identical `if (isCancel(web)) cancel()` branch, but no cancel test was added for it alongside the three other platform steps that received one. The gap is a test-coverage omission, not a runtime defect.

packages/cli/tests/steps-platforms.test.ts — the webStep describe block is missing a cancel test.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/tests/steps-auth.test.ts | Adds a cancel-path test for `authenticationCustomUIStep`; mock setup (mockClear for cancel, mockReturnValueOnce for isCancel) is correct and consistent with the existing suite. |
| packages/cli/tests/steps-platforms.test.ts | Adds cancel-path tests for platformsStep, desktopStep, and mobileStep; promotes isCancel to a controllable mock and introduces cancelMocks correctly, but the webStep describe block (which also calls cancel() on interrupt) is missing an equivalent cancel test. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Interactive prompt called] --> B{isCancel?}
    B -- Yes --> C[cancel utility called]
    C --> D[throws Error 'Cancelled']
    D --> E[Promise rejects]
    B -- No --> F[Process result]
    F --> G{Valid selection?}
    G -- No --> H[log.warn + re-prompt]
    H --> A
    G -- Yes --> I[Return value]

    subgraph "New cancel tests"
        T1[platformsStep multiselect cancel]
        T2[desktopStep select cancel]
        T3[mobileStep select cancel]
        T4[authCustomUI confirm cancel]
    end

    T1 & T2 & T3 & T4 --> B
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cli/tests/steps-platforms.test.ts`, line 139-204 ([link](https://github.com/ryuudotgg/forge/blob/0e3b334364e5c26459e3ec60827286f03258bee8/packages/cli/tests/steps-platforms.test.ts#L139-L204)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing cancel test for `webStep`**

   `web.ts` calls `cancel()` on `isCancel(web)` the same way `desktopStep` and `mobileStep` do, but the `web step` describe block has no corresponding cancel test. Every other interactive platform step (`platformsStep`, `desktopStep`, `mobileStep`) gained a cancel test in this PR — omitting `webStep` leaves that branch untested while the pattern is explicitly being established here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/tests/steps-platforms.test.ts
   Line: 139-204

   Comment:
   **Missing cancel test for `webStep`**

   `web.ts` calls `cancel()` on `isCancel(web)` the same way `desktopStep` and `mobileStep` do, but the `web step` describe block has no corresponding cancel test. Every other interactive platform step (`platformsStep`, `desktopStep`, `mobileStep`) gained a cancel test in this PR — omitting `webStep` leaves that branch untested while the pattern is explicitly being established here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/cli/tests/steps-platforms.test.ts:139-204
**Missing cancel test for `webStep`**

`web.ts` calls `cancel()` on `isCancel(web)` the same way `desktopStep` and `mobileStep` do, but the `web step` describe block has no corresponding cancel test. Every other interactive platform step (`platformsStep`, `desktopStep`, `mobileStep`) gained a cancel test in this PR — omitting `webStep` leaves that branch untested while the pattern is explicitly being established here.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover platform and auth cancel pat..."](https://github.com/ryuudotgg/forge/commit/0e3b334364e5c26459e3ec60827286f03258bee8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37697494)</sub>

<!-- /greptile_comment -->