### PR TITLE
fix: write node version to nvmrc

### DIFF
--- a/packages/generators/src/workspace/root.ts
+++ b/packages/generators/src/workspace/root.ts
@@ -6,6 +6,7 @@ import {
 	packageManagerCommand,
 	projectTarget,
 	runtimeCommand,
+	runtimes,
 	surfaceDependencies,
 	surfaceJson,
 	surfaceScripts,
@@ -44,6 +45,15 @@ const root = defineAddon<ForgeConfig, "root">({
 				),
 			);
 
+			const nodeVersion =
+				runtime === "Node.js"
+					? runtimeVersion
+					: yield* CommandProbe.readVersion("node").pipe(
+							Effect.catchTag("CommandProbeError", () =>
+								Effect.succeed(`${runtimes.node.minimumMajor}`),
+							),
+						);
+
 			const packageManagerVersion = yield* CommandProbe.readVersion(
 				packageManagerCommandName,
 			).pipe(
@@ -56,7 +66,12 @@ const root = defineAddon<ForgeConfig, "root">({
 				),
 			);
 
-			return buildContributions(config, runtimeVersion, packageManagerVersion);
+			return buildContributions(
+				config,
+				runtimeVersion,
+				packageManagerVersion,
+				nodeVersion,
+			);
 		}),
 });
 
@@ -76,6 +91,7 @@ function buildContributions(
 	config: ForgeConfig,
 	runtimeVersion: string,
 	packageManagerVersion: string,
+	nodeVersion: string,
 ) {
 	const slug = config.slug ?? "my-app";
 
@@ -144,7 +160,7 @@ function buildContributions(
 				dev: { cache: false, persistent: true },
 			},
 		}),
-		leafTextFile(projectTarget(), ".nvmrc", `${runtimeVersion}\n`),
+		leafTextFile(projectTarget(), ".nvmrc", `v${nodeVersion}\n`),
 	];
 }
 

--- a/packages/generators/tests/workspace.test.ts
+++ b/packages/generators/tests/workspace.test.ts
@@ -5,6 +5,7 @@ import {
 	type Contribution,
 	GeneratorError,
 	type ManagedSurfaceName,
+	runtimes,
 } from "@ryuujs/core";
 import { Effect, Layer } from "effect";
 import { describe, expect, it } from "vitest";
@@ -188,8 +189,67 @@ describe("root workspace", () => {
 		expect(bare).not.toHaveProperty("tasks.build.outputs");
 	});
 
-	it("pins the probed runtime version in .nvmrc", async () => {
-		expect(leafFile(await rootContributions({}), ".nvmrc")).toBe("22.11.0\n");
+	it("pins the probed node version in .nvmrc for Node.js projects", async () => {
+		expect(leafFile(await rootContributions({}), ".nvmrc")).toBe("v22.11.0\n");
+	});
+
+	it("pins the probed node version in .nvmrc for Bun projects", async () => {
+		const layer = Layer.succeed(
+			CommandProbe,
+			CommandProbe.make({
+				readVersion: (command: string) => {
+					const versions: Record<string, string> = {
+						bun: "1.3.2",
+						node: "24.1.0",
+						pnpm: "10.12.1",
+					};
+					const version = versions[command];
+
+					return version === undefined
+						? Effect.fail(
+								new CommandProbeError({
+									command,
+									message: "Command Probe Failed",
+									detail: "not found",
+								}),
+							)
+						: Effect.succeed(version);
+				},
+			}),
+		);
+		const contributions = await Effect.runPromise(
+			rootEffect({ runtime: "Bun" }).pipe(Effect.provide(layer)),
+		);
+
+		expect(leafFile(contributions, ".nvmrc")).toBe("v24.1.0\n");
+		expect(jsonSurface(contributions, "rootPackageJson")).toMatchObject({
+			engines: { bun: "1.3.2" },
+		});
+	});
+
+	it("falls back to the minimum node major for .nvmrc when node probing fails", async () => {
+		const layer = Layer.succeed(
+			CommandProbe,
+			CommandProbe.make({
+				readVersion: (command: string) =>
+					command === "node"
+						? Effect.fail(
+								new CommandProbeError({
+									command,
+									message: "Command Probe Failed",
+									detail: "not found",
+								}),
+							)
+						: Effect.succeed(command === "bun" ? "1.3.2" : "10.12.1"),
+			}),
+		);
+		const contributions = await Effect.runPromise(
+			rootEffect({ runtime: "Bun" }).pipe(Effect.provide(layer)),
+		);
+
+		expect(leafFile(contributions, ".nvmrc")).toBe(
+			`v${runtimes.node.minimumMajor}\n`,
+		);
 	});
 
 	it("fails with a generator error when the runtime probe fails", async () => {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes generated workspace `.nvmrc` content to pin Node.js directly. The main changes are:

- Added a Node version probe for non-Node runtimes.
- Added a fallback to the configured minimum Node major.
- Changed generated `.nvmrc` values to use a `v` prefix.
- Added tests for Node.js and Bun workspace generation.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the executable focused Vitest test defined in trex-artifacts/nvmrc-node-version-test.ts for both commits.
- Evaluated the base run output captured in trex-artifacts/nvmrc-node-version-01-before.log, which shows the contract was not met in the base run.
- Evaluated the head run output captured in trex-artifacts/nvmrc-node-version-02-after.log, which shows all asserted contract checks pass in the head run.

<a href="https://app.greptile.com/trex/runs/13266924/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/generators/src/workspace/root.ts | Generates `.nvmrc` from a Node-specific version while preserving runtime-specific engine output. |
| packages/generators/tests/workspace.test.ts | Adds tests for Node.js `.nvmrc` output, Bun Node probing, and the fallback path. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: write node version to nvmrc"](https://github.com/ryuudotgg/forge/commit/d41cd4dcde9270f40f9526b33dac9b6fea252480) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41802790)</sub>

<!-- /greptile_comment -->