### PR TITLE
fix(ui): add tailwind deps to generated web app

### DIFF
--- a/packages/generators/src/ui/index.ts
+++ b/packages/generators/src/ui/index.ts
@@ -154,6 +154,14 @@ const ui = defineAddon<ForgeConfig, "ui", "nextjs">({
 			surfaceJson(ensuredModuleTarget("ui"), "packageJson", uiPackageJson),
 			surfaceJson(ensuredModuleTarget("ui"), "tsconfig", uiTsconfig),
 			surfaceDependencies(ensuredModuleTarget("ui"), "packageJson", uiDeps),
+			...(useTailwind
+				? [
+						surfaceDependencies(ensuredModuleTarget("web"), "packageJson", [
+							{ ...deps.tailwindcss, type: "devDependencies" },
+							{ ...deps.tailwindPostcss, type: "devDependencies" },
+						]),
+					]
+				: []),
 
 			leafTextFile(
 				ensuredModuleTarget("ui"),

--- a/packages/generators/tests/ui.test.ts
+++ b/packages/generators/tests/ui.test.ts
@@ -43,19 +43,44 @@ function leafFile(
 	);
 }
 
-function packageJsonSurface(contributions: ReadonlyArray<Contribution>) {
+function packageJsonSurface(
+	contributions: ReadonlyArray<Contribution>,
+	moduleKey = "ui",
+) {
 	return must(
 		contributions
 			.filter(byTag("ManagedJsonSurfaceContribution"))
-			.find((entry) => entry.surface === "packageJson"),
-		"packageJson",
+			.find(
+				(entry) =>
+					entry.surface === "packageJson" &&
+					entry.target._tag === "EnsuredModuleTarget" &&
+					entry.target.moduleKey === moduleKey,
+			),
+		`${moduleKey} packageJson`,
 	);
 }
 
-function dependencyEntries(contributions: ReadonlyArray<Contribution>) {
+function dependencySurface(
+	contributions: ReadonlyArray<Contribution>,
+	moduleKey = "ui",
+) {
+	return contributions
+		.filter(byTag("ManagedDependenciesSurfaceContribution"))
+		.find(
+			(entry) =>
+				entry.surface === "packageJson" &&
+				entry.target._tag === "EnsuredModuleTarget" &&
+				entry.target.moduleKey === moduleKey,
+		);
+}
+
+function dependencyEntries(
+	contributions: ReadonlyArray<Contribution>,
+	moduleKey = "ui",
+) {
 	return must(
-		contributions.find(byTag("ManagedDependenciesSurfaceContribution")),
-		"packageJson dependencies",
+		dependencySurface(contributions, moduleKey),
+		`${moduleKey} packageJson dependencies`,
 	).dependencies;
 }
 
@@ -131,7 +156,7 @@ describe("ui addon", () => {
 
 	it("gates the tailwind toolchain on the style selection", () => {
 		const withTailwind = contributionsFor(baseConfig);
-		expect(dependencyEntries(withTailwind)).toEqual(
+		expect(dependencyEntries(withTailwind, "ui")).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
 					name: "tailwindcss",
@@ -148,6 +173,18 @@ describe("ui addon", () => {
 				expect.objectContaining({ name: "shadcn", type: "devDependencies" }),
 			]),
 		);
+		expect(dependencyEntries(withTailwind, "web")).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: "tailwindcss",
+					type: "devDependencies",
+				}),
+				expect.objectContaining({
+					name: "@tailwindcss/postcss",
+					type: "devDependencies",
+				}),
+			]),
+		);
 
 		const ensure = must(
 			withTailwind.find(byTag("EnsureModuleContribution")),
@@ -160,7 +197,7 @@ describe("ui addon", () => {
 		});
 
 		const withoutStyle = contributionsFor({ slug: "acme", web: "nextjs" });
-		const names = dependencyEntries(withoutStyle).map(({ name }) => name);
+		const names = dependencyEntries(withoutStyle, "ui").map(({ name }) => name);
 		for (const name of [
 			"tailwindcss",
 			"@tailwindcss/postcss",
@@ -168,6 +205,12 @@ describe("ui addon", () => {
 			"shadcn",
 		])
 			expect(names).not.toContain(name);
+
+		const webNames = (
+			dependencySurface(withoutStyle, "web")?.dependencies ?? []
+		).map(({ name }) => name);
+		for (const name of ["tailwindcss", "@tailwindcss/postcss"])
+			expect(webNames).not.toContain(name);
 
 		const cssEnsure = must(
 			withoutStyle.find(byTag("EnsureModuleContribution")),


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Tailwind dependencies to the generated web app. The main changes are:

- Adds `tailwindcss` and `@tailwindcss/postcss` devDependencies to the web package when Tailwind styling is selected.
- Keeps the existing UI package dependency behavior.
- Updates UI generator tests to check dependency surfaces by module key.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the trex-tailwind-web-deps test using pnpm --filter @ryuujs/generators exec vitest run tests/trex-tailwind-web-deps.test.ts --reporter=verbose to validate web dependencies.
- In the base run, TAILWIND\_ENABLED\_WEB\_DEPS and NO\_STYLE\_WEB\_DEPS were absent.
- In the head run, TAILWIND\_ENABLED\_WEB\_DEPS includes tailwindcss and @tailwindcss/postcss as devDependencies, while NO\_STYLE\_WEB\_DEPS remains absent.

<a href="https://app.greptile.com/trex/runs/13267948/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/generators/src/ui/index.ts | Adds Tailwind and PostCSS devDependencies to the generated web module when Tailwind is enabled. |
| packages/generators/tests/ui.test.ts | Updates helpers and assertions to validate UI and web dependency surfaces separately. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): add tailwind deps to generated ..."](https://github.com/ryuudotgg/forge/commit/726e70b3daf2312aa106430ec8f061947b4c108c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41804775)</sub>

<!-- /greptile_comment -->