### PR TITLE
ci: smoke core and cli changes on PRs

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -6,10 +6,11 @@ on:
 
   pull_request:
     paths:
-      - "packages/cli/src/**"
-      - "packages/core/src/**"
-      - "packages/generators/src/**"
-      - "packages/generators/templates/**"
+      - "packages/cli/**"
+      - "packages/core/**"
+      - "packages/generators/**"
+      - "!packages/*/tests/**"
+      - "pnpm-lock.yaml"
       - "tests/scenarios/src/scenarios/install.smoke.test.ts"
       - "tests/scenarios/src/utils/**"
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -6,9 +6,12 @@ on:
 
   pull_request:
     paths:
+      - "packages/cli/src/**"
+      - "packages/core/src/**"
       - "packages/generators/src/**"
       - "packages/generators/templates/**"
       - "tests/scenarios/src/scenarios/install.smoke.test.ts"
+      - "tests/scenarios/src/utils/**"
 
   schedule:
     - cron: "0 4 * * *"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands when the smoke workflow runs on pull requests. The main changes are:

- Added CLI source changes to the smoke workflow path filter.
- Added core source changes to the smoke workflow path filter.
- Added scenario utility changes to the smoke workflow path filter.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small cleanup to the smoke path filters.

The workflow change broadens existing smoke coverage, but package manifests, build configs, and dependency inputs can still affect the CLI build without triggering this smoke job.

.github/workflows/smoke.yml

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- After changes, the head workflow path extraction now includes packages/cli/src/\*\* and packages/core/src/\*\*, and all CLI/core src examples match their paths with overall=true.
- After changes, the scenario-utils smoke PR path check shows tests/scenarios/src/utils/\*\* is included and would\_trigger=true.

<a href="https://app.greptile.com/trex/runs/13314815/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/smoke.yml | Adds pull request path filters for CLI, core, and scenario utility changes, with a remaining gap for package and build inputs outside `src/**`. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/smoke.yml:9-10
**Package Surface Skips Smoke**

When a PR changes CLI or core files outside `src/**`, such as `package.json`, `tsdown.config.ts`, or dependency lockfile inputs, this workflow does not run even though the smoke job builds `@ryuujs/forge` from that package surface. The regular scenarios job does not set `FORGE_SMOKE`, so the install smoke suite can be skipped for build and dependency changes that affect the generated CLI binary.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: smoke core and cli changes on PRs"](https://github.com/ryuudotgg/forge/commit/456ea186a1f517556722d71e0b3099eeef9b9967) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41897018)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->