### PR TITLE
fix(cli): soften install and git init failures

### DIFF
--- a/packages/cli/src/steps/post/git-init.ts
+++ b/packages/cli/src/steps/post/git-init.ts
@@ -1,7 +1,7 @@
-import { confirm, isCancel, text } from "@clack/prompts";
+import { confirm, isCancel, log, text } from "@clack/prompts";
 import { Command } from "@effect/platform";
 import { NodeContext } from "@effect/platform-node";
-import { Effect } from "effect";
+import { Effect, Exit } from "effect";
 import { cancel } from "../../utils/cancel";
 import { defineStep, SKIP } from "../types";
 
@@ -27,6 +27,15 @@ function gitInit(dir: string, message: string) {
 	}).pipe(Effect.provide(NodeContext.layer));
 }
 
+async function runGitInit(dir: string, message: string) {
+	const exit = await Effect.runPromiseExit(gitInit(dir, message));
+
+	if (Exit.isFailure(exit))
+		log.warn(
+			"We couldn't create the initial commit, so set up git yourself when you're ready.",
+		);
+}
+
 const gitInitStep = defineStep({
 	id: "gitInit",
 	group: "outro",
@@ -41,7 +50,7 @@ const gitInitStep = defineStep({
 		const dir = String(config.path);
 
 		if (!interactive) {
-			await Effect.runPromise(gitInit(dir, DEFAULT_MESSAGE));
+			await runGitInit(dir, DEFAULT_MESSAGE);
 			return SKIP;
 		}
 
@@ -62,7 +71,7 @@ const gitInitStep = defineStep({
 
 		if (isCancel(message)) cancel();
 
-		await Effect.runPromise(gitInit(dir, message || DEFAULT_MESSAGE));
+		await runGitInit(dir, message || DEFAULT_MESSAGE);
 	},
 });
 

--- a/packages/cli/src/steps/post/install-deps.ts
+++ b/packages/cli/src/steps/post/install-deps.ts
@@ -1,8 +1,8 @@
-import { confirm, isCancel, spinner } from "@clack/prompts";
+import { confirm, isCancel, log, spinner } from "@clack/prompts";
 import { Command } from "@effect/platform";
 import { NodeContext } from "@effect/platform-node";
 import { type PackageManager, packageManagerCommand } from "@ryuujs/core";
-import { Effect, Schema } from "effect";
+import { Effect, Exit, Schema } from "effect";
 import { cancel } from "../../utils/cancel";
 import { defineStep, SKIP } from "../types";
 
@@ -35,6 +35,28 @@ function installDeps(
 	}).pipe(Effect.provide(NodeContext.layer));
 }
 
+async function runInstall(
+	pm: PackageManager,
+	cmd: ReturnType<typeof packageManagerCommand>,
+	dir: string,
+) {
+	const s = spinner();
+	s.start("We're installing your dependencies...");
+
+	const exit = await Effect.runPromiseExit(installDeps(pm, cmd, dir));
+
+	if (Exit.isFailure(exit)) {
+		s.stop("We couldn't install your dependencies.");
+		log.warn(
+			`The ${pm} install didn't finish, so run it yourself inside the project when you're ready.`,
+		);
+
+		return;
+	}
+
+	s.stop("We've installed your dependencies!");
+}
+
 const installDepsStep = defineStep({
 	id: "installDeps",
 	group: "outro",
@@ -51,12 +73,7 @@ const installDepsStep = defineStep({
 		const dir = String(config.path);
 
 		if (!interactive) {
-			const s = spinner();
-
-			s.start("We're installing your dependencies...");
-			await Effect.runPromise(installDeps(pm, cmd, dir));
-			s.stop("We've installed your dependencies!");
-
+			await runInstall(pm, cmd, dir);
 			return SKIP;
 		}
 
@@ -69,11 +86,7 @@ const installDepsStep = defineStep({
 		if (isCancel(shouldInstall)) cancel();
 		if (!shouldInstall) return SKIP;
 
-		const s = spinner();
-
-		s.start("We're installing your dependencies...");
-		await Effect.runPromise(installDeps(pm, cmd, dir));
-		s.stop("We've installed your dependencies!");
+		await runInstall(pm, cmd, dir);
 	},
 });
 

--- a/packages/cli/tests/steps-post.test.ts
+++ b/packages/cli/tests/steps-post.test.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { Command as PlatformCommand } from "@effect/platform";
 import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import gitInitStep from "../src/steps/post/git-init";
@@ -12,6 +13,7 @@ import { SKIP } from "../src/steps/types";
 const promptMocks = vi.hoisted(() => ({
 	confirm: vi.fn(),
 	isCancel: vi.fn(() => false),
+	log: { warn: vi.fn() },
 	spinner: vi.fn(),
 	spinnerStart: vi.fn(),
 	spinnerStop: vi.fn(),
@@ -20,6 +22,8 @@ const promptMocks = vi.hoisted(() => ({
 
 const commandMocks = vi.hoisted(() => ({
 	exitCode: vi.fn(),
+	failCommit: false,
+	string: vi.fn(),
 }));
 
 const cancelMocks = vi.hoisted(() => ({
@@ -31,6 +35,7 @@ const cancelMocks = vi.hoisted(() => ({
 vi.mock("@clack/prompts", () => ({
 	confirm: promptMocks.confirm,
 	isCancel: promptMocks.isCancel,
+	log: promptMocks.log,
 	spinner: promptMocks.spinner,
 	text: promptMocks.text,
 }));
@@ -40,11 +45,20 @@ vi.mock("../src/utils/cancel", () => ({ cancel: cancelMocks.cancel }));
 vi.mock("@effect/platform", async (importOriginal) => {
 	const original = await importOriginal<typeof import("@effect/platform")>();
 
+	commandMocks.string.mockImplementation((command: PlatformCommand.Command) =>
+		commandMocks.failCommit &&
+		command._tag === "StandardCommand" &&
+		command.args[0] === "commit"
+			? Effect.fail("fatal: unable to auto-detect email address")
+			: original.Command.string(command),
+	);
+
 	return {
 		...original,
 		Command: {
 			...original.Command,
 			exitCode: commandMocks.exitCode,
+			string: commandMocks.string,
 		},
 	};
 });
@@ -99,6 +113,7 @@ beforeEach(() => {
 	promptMocks.confirm.mockReset();
 	promptMocks.isCancel.mockReset();
 	promptMocks.isCancel.mockReturnValue(false);
+	promptMocks.log.warn.mockReset();
 	promptMocks.spinner.mockReset();
 	promptMocks.spinnerStart.mockReset();
 	promptMocks.spinnerStop.mockReset();
@@ -110,6 +125,8 @@ beforeEach(() => {
 	}));
 	commandMocks.exitCode.mockReset();
 	commandMocks.exitCode.mockReturnValue(Effect.succeed(0));
+	commandMocks.string.mockClear();
+	commandMocks.failCommit = false;
 	cancelMocks.cancel.mockClear();
 });
 
@@ -219,6 +236,23 @@ describe("git init step", () => {
 			expect(existsSync(join(directory, ".git"))).toBe(false);
 		});
 	});
+
+	it("warns and resolves when the commit fails", async () => {
+		await withTempDir("git-init-fail", async (directory) => {
+			await writeFile(join(directory, "README.md"), "# Forge\n", "utf-8");
+			commandMocks.failCommit = true;
+
+			await withGitEnv(async () => {
+				await expect(
+					gitInitStep.execute({ path: directory }, false),
+				).resolves.toBe(SKIP);
+			});
+
+			expect(promptMocks.log.warn).toHaveBeenCalledWith(
+				"We couldn't create the initial commit, so set up git yourself when you're ready.",
+			);
+		});
+	});
 });
 
 describe("install deps step", () => {
@@ -279,7 +313,7 @@ describe("install deps step", () => {
 		);
 	});
 
-	it("fails with the install error when the command exits non-zero", async () => {
+	it("warns and resolves when the install command exits non-zero (non-interactive)", async () => {
 		commandMocks.exitCode.mockReturnValue(Effect.succeed(1));
 
 		await expect(
@@ -287,8 +321,30 @@ describe("install deps step", () => {
 				{ packageManager: "pnpm", path: "./project" },
 				false,
 			),
-		).rejects.toThrow("Install Failed: pnpm Exited With Code 1");
+		).resolves.toBe(SKIP);
 
-		expect(promptMocks.spinnerStop).not.toHaveBeenCalled();
+		expect(promptMocks.spinnerStop).toHaveBeenCalledWith(
+			"We couldn't install your dependencies.",
+		);
+		expect(promptMocks.log.warn).toHaveBeenCalledWith(
+			"The pnpm install didn't finish, so run it yourself inside the project when you're ready.",
+		);
+	});
+
+	it("warns and resolves when the install command exits non-zero (interactive)", async () => {
+		promptMocks.confirm.mockResolvedValue(true);
+		commandMocks.exitCode.mockReturnValue(Effect.succeed(1));
+
+		await installDepsStep.execute(
+			{ packageManager: "pnpm", path: "./project" },
+			true,
+		);
+
+		expect(promptMocks.spinnerStop).toHaveBeenCalledWith(
+			"We couldn't install your dependencies.",
+		);
+		expect(promptMocks.log.warn).toHaveBeenCalledWith(
+			"The pnpm install didn't finish, so run it yourself inside the project when you're ready.",
+		);
 	});
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR softens post-generation setup failures. The main changes are:

- Git initialization now warns instead of throwing on failure.
- Dependency installation now warns instead of throwing on failure.
- Post-step tests now cover warning-and-resolve behavior.

<h3>Confidence Score: 4/5</h3>

The non-interactive install path can report success after a failed dependency install.

Package-manager failures are now converted into warnings, and config-driven runs can continue to git init and finish with a success exit.

packages/cli/src/steps/post/install-deps.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Vitest harness against the install-deps and git-init orchestration path with Command.exitCode mocked to return 1, revealing how the system handles an install failure.
- T-Rex produced a proof for a posted P1 finding, linking to the corresponding review comment.
- Inspected the git-init soft-failure path using the provided before/after artifacts and confirmed that both base and head show EXECUTE\_RESOLVED: undefined and WARN\_CALLS: \[\], with a staged README and a git log status of 128, indicating no commits on master.

<a href="https://app.greptile.com/trex/runs/13316174/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/steps/post/install-deps.ts | Adds shared install failure handling, but non-interactive install failures no longer signal command failure. |
| packages/cli/src/steps/post/git-init.ts | Adds shared git-init failure handling that warns and continues when git setup or commit fails. |
| packages/cli/tests/steps-post.test.ts | Updates mocks and tests for the new warning-based post-step failure behavior. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Git init step continues silently when the initial commit is not created**

   - **Bug**
     - Under an isolated git configuration with no user.name/user.email, executing the non-interactive git init post step on head leaves the repository with `README.md` staged and no commits, but no `@clack/prompts` `log.warn` call is emitted. The PR contract requires the step to warn the user with `We couldn't create the initial commit, so set up git yourself when you're ready.` while continuing.
   - **Cause**
     - `packages/cli/src/steps/post/git-init.ts` uses `Effect.runPromiseExit(gitInit(...))` and checks only `Exit.isFailure(exit)`, but the commit failure in this runtime path is not surfaced as a failing Exit; the command completes with no commit created and the warning branch is not reached.
   - **Fix**
     - At `runGitInit`, ensure the git commit command's non-zero/no-commit result is treated as a failure before returning, or explicitly verify that an initial commit exists after `git commit` and call `log.warn("We couldn't create the initial commit, so set up git yourself when you're ready.")` when it does not.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/cli/src/steps/post/install-deps.ts:54
**Install Failure Exits Successfully**

When `pnpm install` or another package-manager command exits non-zero in config-driven non-interactive mode, this branch logs a warning and returns normally. The caller then returns `SKIP`, the orchestrator continues to git init/outro, and the CLI can exit with success even though dependencies were not installed.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): soften install and git init fa..."](https://github.com/ryuudotgg/forge/commit/bc291591654d65386c657004273d76e5533b610f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41899558)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->