### PR TITLE
fix(db): index userId on pg and sqlite auth tables

### DIFF
--- a/packages/generators/src/orm/prisma/index.ts
+++ b/packages/generators/src/orm/prisma/index.ts
@@ -48,7 +48,6 @@ const prisma = defineAddon<ForgeConfig, "prisma", "nextjs">({
 			RELATION_MODE: emulatesRelations
 				? `\n  relationMode = "${provider.prisma.relationMode}"`
 				: "",
-			RELATION_INDEX: emulatesRelations ? "  @@index([userId])\n\n" : "",
 			TEXT: provider.prisma.datasourceProvider === "mysql" ? " @db.Text" : "",
 			TIMESTAMPTZ:
 				provider.prisma.datasourceProvider === "postgresql"

--- a/packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.sqlite.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.sqlite.ts
@@ -1,52 +1,60 @@
 import { sql } from "drizzle-orm";
-import { integer, snakeCase, text } from "drizzle-orm/sqlite-core";
+import { index, integer, snakeCase, text } from "drizzle-orm/sqlite-core";
 
 import { users } from "./users";
 
 const unixepochMs = sql`(cast(unixepoch('subsecond') * 1000 as integer))`;
 
-export const sessions = snakeCase.table("sessions", {
-  id: text().primaryKey(),
-  userId: text()
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
+export const sessions = snakeCase.table(
+  "sessions",
+  {
+    id: text().primaryKey(),
+    userId: text()
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
 
-  token: text().notNull().unique(),
-  expiresAt: integer({ mode: "timestamp_ms" }).notNull(),
+    token: text().notNull().unique(),
+    expiresAt: integer({ mode: "timestamp_ms" }).notNull(),
 
-  ipAddress: text(),
-  userAgent: text(),
+    ipAddress: text(),
+    userAgent: text(),
 
-  createdAt: integer({ mode: "timestamp_ms" }).notNull().default(unixepochMs),
-  updatedAt: integer({ mode: "timestamp_ms" })
-    .notNull()
-    .default(unixepochMs)
-    .$onUpdate(() => new Date()),
-});
+    createdAt: integer({ mode: "timestamp_ms" }).notNull().default(unixepochMs),
+    updatedAt: integer({ mode: "timestamp_ms" })
+      .notNull()
+      .default(unixepochMs)
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [index("sessions_user_id_idx").on(table.userId)],
+);
 
-export const accounts = snakeCase.table("accounts", {
-  id: text().primaryKey(),
-  userId: text()
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
+export const accounts = snakeCase.table(
+  "accounts",
+  {
+    id: text().primaryKey(),
+    userId: text()
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
 
-  accountId: text().notNull(),
-  providerId: text().notNull(),
+    accountId: text().notNull(),
+    providerId: text().notNull(),
 
-  accessToken: text(),
-  accessTokenExpiresAt: integer({ mode: "timestamp_ms" }),
+    accessToken: text(),
+    accessTokenExpiresAt: integer({ mode: "timestamp_ms" }),
 
-  refreshToken: text(),
-  refreshTokenExpiresAt: integer({ mode: "timestamp_ms" }),
+    refreshToken: text(),
+    refreshTokenExpiresAt: integer({ mode: "timestamp_ms" }),
 
-  scope: text(),
+    scope: text(),
 
-  createdAt: integer({ mode: "timestamp_ms" }).notNull().default(unixepochMs),
-  updatedAt: integer({ mode: "timestamp_ms" })
-    .notNull()
-    .default(unixepochMs)
-    .$onUpdate(() => new Date()),
-});
+    createdAt: integer({ mode: "timestamp_ms" }).notNull().default(unixepochMs),
+    updatedAt: integer({ mode: "timestamp_ms" })
+      .notNull()
+      .default(unixepochMs)
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [index("accounts_user_id_idx").on(table.userId)],
+);
 
 export const verifications = snakeCase.table("verifications", {
   id: text().primaryKey(),

--- a/packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.ts
+++ b/packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.ts
@@ -1,49 +1,57 @@
-import { snakeCase, text, timestamp } from "drizzle-orm/pg-core";
+import { index, snakeCase, text, timestamp } from "drizzle-orm/pg-core";
 
 import { users } from "./users";
 
-export const sessions = snakeCase.table("sessions", {
-  id: text().primaryKey(),
-  userId: text()
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
+export const sessions = snakeCase.table(
+  "sessions",
+  {
+    id: text().primaryKey(),
+    userId: text()
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
 
-  token: text().notNull().unique(),
-  expiresAt: timestamp({ withTimezone: true }).notNull(),
+    token: text().notNull().unique(),
+    expiresAt: timestamp({ withTimezone: true }).notNull(),
 
-  ipAddress: text(),
-  userAgent: text(),
+    ipAddress: text(),
+    userAgent: text(),
 
-  createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp({ withTimezone: true })
-    .notNull()
-    .defaultNow()
-    .$onUpdate(() => new Date()),
-});
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp({ withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [index("sessions_user_id_idx").on(table.userId)],
+);
 
-export const accounts = snakeCase.table("accounts", {
-  id: text().primaryKey(),
-  userId: text()
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
+export const accounts = snakeCase.table(
+  "accounts",
+  {
+    id: text().primaryKey(),
+    userId: text()
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
 
-  accountId: text().notNull(),
-  providerId: text().notNull(),
+    accountId: text().notNull(),
+    providerId: text().notNull(),
 
-  accessToken: text(),
-  accessTokenExpiresAt: timestamp({ withTimezone: true }),
+    accessToken: text(),
+    accessTokenExpiresAt: timestamp({ withTimezone: true }),
 
-  refreshToken: text(),
-  refreshTokenExpiresAt: timestamp({ withTimezone: true }),
+    refreshToken: text(),
+    refreshTokenExpiresAt: timestamp({ withTimezone: true }),
 
-  scope: text(),
+    scope: text(),
 
-  createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp({ withTimezone: true })
-    .notNull()
-    .defaultNow()
-    .$onUpdate(() => new Date()),
-});
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp({ withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [index("accounts_user_id_idx").on(table.userId)],
+);
 
 export const verifications = snakeCase.table("verifications", {
   id: text().primaryKey(),

--- a/packages/generators/templates/orm/prisma/packages/db/prisma/schema.prisma
+++ b/packages/generators/templates/orm/prisma/packages/db/prisma/schema.prisma
@@ -40,7 +40,9 @@ model Session {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-__RELATION_INDEX__  @@map("sessions")
+  @@index([userId])
+
+  @@map("sessions")
 }
 
 model Account {
@@ -63,7 +65,9 @@ model Account {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-__RELATION_INDEX__  @@map("accounts")
+  @@index([userId])
+
+  @@map("accounts")
 }
 
 model Verification {

--- a/packages/generators/tests/orm.test.ts
+++ b/packages/generators/tests/orm.test.ts
@@ -202,7 +202,8 @@ describe("prisma addon", () => {
 		const schema = leafFile(withAuth, "prisma/schema.prisma");
 		expect(schema).toContain("model Session");
 		expect(schema).toContain('@@map("sessions")');
-		expect(schema).not.toContain("@@index");
+		expect(schema).toContain("  @@index([userId])");
+		expect(schema).not.toContain("relationMode");
 		expect(schema).not.toContain("__");
 	});
 
@@ -336,9 +337,12 @@ describe("drizzle addon", () => {
 			authentication: "better-auth",
 		});
 
-		expect(leafFile(contributions, "src/schema/auth.ts")).toContain(
-			'export const sessions = snakeCase.table("sessions"',
+		const authSchema = leafFile(contributions, "src/schema/auth.ts");
+		expect(authSchema).toContain(
+			'export const sessions = snakeCase.table(\n  "sessions"',
 		);
+		expect(authSchema).toContain("sessions_user_id_idx");
+		expect(authSchema).toContain("accounts_user_id_idx");
 		expect(leafFile(contributions, "src/schema/index.ts")).toBe(
 			'export * from "./auth";\nexport * from "./users";\n',
 		);
@@ -388,6 +392,19 @@ describe("drizzle addon", () => {
 		expect(leafFile(contributions, "src/client.ts")).toContain(
 			"createClient({ url: env.DATABASE_URL })",
 		);
+	});
+
+	it("indexes userId on the sqlite auth schema for better-auth", () => {
+		const contributions = contributionsFor(drizzle, {
+			slug: "acme",
+			orm: "drizzle",
+			database: "sqlite",
+			authentication: "better-auth",
+		});
+
+		const authSchema = leafFile(contributions, "src/schema/auth.ts");
+		expect(authSchema).toContain("sessions_user_id_idx");
+		expect(authSchema).toContain("accounts_user_id_idx");
 	});
 
 	it("maps the planetscale mysql driver deps and templates", () => {

--- a/tests/scenarios/src/scenarios/better-auth.test.ts
+++ b/tests/scenarios/src/scenarios/better-auth.test.ts
@@ -48,17 +48,19 @@ describe("better auth", () => {
 			expect(auth).not.toContain("__SLUG__");
 
 			expect(authSchema).toContain(
-				'import { snakeCase, text, timestamp } from "drizzle-orm/pg-core";',
+				'import { index, snakeCase, text, timestamp } from "drizzle-orm/pg-core";',
 			);
 			expect(authSchema).toContain(
-				'export const sessions = snakeCase.table("sessions"',
+				'export const sessions = snakeCase.table(\n  "sessions"',
 			);
 			expect(authSchema).toContain(
-				'export const accounts = snakeCase.table("accounts"',
+				'export const accounts = snakeCase.table(\n  "accounts"',
 			);
 			expect(authSchema).toContain(
 				'.references(() => users.id, { onDelete: "cascade" })',
 			);
+			expect(authSchema).toContain("sessions_user_id_idx");
+			expect(authSchema).toContain("accounts_user_id_idx");
 
 			expect(schemaIndex).toContain('export * from "./auth";');
 

--- a/tests/scenarios/src/scenarios/database-providers.test.ts
+++ b/tests/scenarios/src/scenarios/database-providers.test.ts
@@ -357,12 +357,14 @@ export const db = drizzle({ client, relations });
 			);
 
 			expect(authSchema).toContain(
-				'export const sessions = snakeCase.table("sessions", {',
+				'export const sessions = snakeCase.table(\n  "sessions",',
 			);
 			expect(authSchema).toContain('integer({ mode: "timestamp_ms" })');
 			expect(authSchema).toContain(
 				'.references(() => users.id, { onDelete: "cascade" })',
 			);
+			expect(authSchema).toContain("sessions_user_id_idx");
+			expect(authSchema).toContain("accounts_user_id_idx");
 
 			expect(schemaIndex).toContain('export * from "./auth";');
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `userId` indexes to generated Better Auth database schemas.

- Adds Prisma `@@index([userId])` entries for `Session` and `Account`.
- Adds Drizzle PostgreSQL and SQLite indexes for `sessions.userId` and `accounts.userId`.
- Updates generator and scenario tests for the new rendered schema output.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the before and after drizzle-auth index outputs to verify that sessions\_user\_id\_idx and accounts\_user\_id\_idx were missing initially and were added as index(...).on(table.userId) after the change.
- Executed contract-validation tests for PostgreSQL and SQLite models; observed that the pre-change results were false for all four checks and the post-change results were true, with both runs exiting successfully.
- Uploaded and linked four artifacts documenting the before/after index states and the test-result validations.

<a href="https://app.greptile.com/trex/runs/13317126/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/generators/src/orm/prisma/index.ts | Removes the unused relation-index interpolation after the Prisma auth template now emits the indexes directly. |
| packages/generators/templates/orm/prisma/packages/db/prisma/schema.prisma | Adds explicit `userId` indexes to the Prisma Better Auth `Session` and `Account` models. |
| packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.ts | Adds PostgreSQL Drizzle index definitions for Better Auth `sessions` and `accounts`. |
| packages/generators/templates/orm/drizzle/packages/db/src/schema/auth.sqlite.ts | Adds SQLite Drizzle index definitions for Better Auth `sessions` and `accounts`. |
| packages/generators/tests/orm.test.ts | Updates generator tests to expect the new Prisma and Drizzle auth index output. |
| tests/scenarios/src/scenarios/better-auth.test.ts | Updates Better Auth scenario expectations for the new PostgreSQL Drizzle auth schema output. |
| tests/scenarios/src/scenarios/database-providers.test.ts | Updates database provider scenario expectations for the new SQLite auth index output. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(db): index userId on pg and sqlite a..."](https://github.com/ryuudotgg/forge/commit/458b3762a9f94e0d50ee438f7d2b7bad158123a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41901277)</sub>

<!-- /greptile_comment -->