### PR TITLE
chore: drop global turbo, pin sherif locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 		"build": "turbo run build",
 		"check": "turbo run check --continue",
 		"check:fix": "turbo run check --continue -- --write",
-		"check:ws": "pnpm dlx sherif@latest",
+		"check:ws": "sherif",
 		"clean": "git clean -xdf .turbo node_modules",
 		"clean:workspaces": "turbo run clean",
 		"dev": "turbo watch dev --continue",
@@ -21,6 +21,7 @@
 		"@commitlint/config-conventional": "catalog:lint",
 		"@commitlint/types": "catalog:lint",
 		"lefthook": "catalog:dev",
+		"sherif": "catalog:lint",
 		"turbo": "catalog:monorepo",
 		"typescript": "catalog:dev"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ catalogs:
     '@commitlint/types':
       specifier: ^21.2.0
       version: 21.2.0
+    sherif:
+      specifier: ^1.11.1
+      version: 1.13.0
   monorepo:
     turbo:
       specifier: ^2.10.3
@@ -85,6 +88,9 @@ importers:
       lefthook:
         specifier: catalog:dev
         version: 2.1.9
+      sherif:
+        specifier: catalog:lint
+        version: 1.13.0
       turbo:
         specifier: catalog:monorepo
         version: 2.10.3
@@ -1371,6 +1377,54 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  sherif-darwin-arm64@1.13.0:
+    resolution: {integrity: sha512-k38jpGpZIEWS5dpSRLSvVi53LZuGO3hDqB88jgdLMDN11LZM6yTDcP0GytnQ8OpE6Br/Js6bDCLsdWDarZdV9g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  sherif-darwin-x64@1.13.0:
+    resolution: {integrity: sha512-W2bOj0Ya9A0fPSWzbeaaNg2RRRr48l2lArN8sGbfc9SZuJSJWXcdWkTVC3sEUiiXwpxNeLY/CsGNyQz5Izbfig==}
+    cpu: [x64]
+    os: [darwin]
+
+  sherif-linux-arm64-musl@1.13.0:
+    resolution: {integrity: sha512-9IDAlwYT5Ay2nex9Da3R98cvnPKVveT57i7pJXnnY/DC90qdqqz6Twlp7STRv+7qo4k4ES+2J9zQ0k6SDe888A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  sherif-linux-arm64@1.13.0:
+    resolution: {integrity: sha512-Z94SgKNClWarVJj4LsayOmL7zccCUAvy3ugZnIO860FoJofh812KAyF8CdWrSho8qfmmoAzNcqSSc1OZh7+ckQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  sherif-linux-x64-musl@1.13.0:
+    resolution: {integrity: sha512-2L+A8jF5ylojFwl7eAePR1h3Bzx24IcMgEoWObXgD70k6xF+GOJaM/n+q4MQ9YDntAKbJfMDr6ETjt6Bt/hosA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  sherif-linux-x64@1.13.0:
+    resolution: {integrity: sha512-xGB9iiet8l/i8/YLZje8icpZyt4pVgoxB2+SoC6JCB8iDWsCVSuixebwX2t9yeGqXBXO1kphaW0TLf8Tmwy9JQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  sherif-windows-arm64@1.13.0:
+    resolution: {integrity: sha512-jHzJ/EcG4HuNLf/3AEDzbRkAofLPBHRJKJJMjAosampAe9861atu4q+Z2IZ1/sHg5oVnNgaNg/Xc5DDhGcQ/3w==}
+    cpu: [arm64]
+    os: [win32]
+
+  sherif-windows-x64@1.13.0:
+    resolution: {integrity: sha512-KyMqQY62Eb3O+wePlw433mH2XBPVPLXdDjWPneg9pB6jeK0B1sgEzM2yks+aAP5asZ1Y8Q7C7iR7ZtbJKdsAtA==}
+    cpu: [x64]
+    os: [win32]
+
+  sherif@1.13.0:
+    resolution: {integrity: sha512-Ld2nUOlwW1nmYDA2Q/5o7SC8WcCzVS7XjImmzW4a4z1o8DXJnt+2xYLvI42N5UYlNb/EevPahdC/XxIP6C38TQ==}
+    hasBin: true
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -2578,6 +2632,41 @@ snapshots:
       '@rolldown/binding-win32-x64-msvc': 1.1.4
 
   semver@7.8.5: {}
+
+  sherif-darwin-arm64@1.13.0:
+    optional: true
+
+  sherif-darwin-x64@1.13.0:
+    optional: true
+
+  sherif-linux-arm64-musl@1.13.0:
+    optional: true
+
+  sherif-linux-arm64@1.13.0:
+    optional: true
+
+  sherif-linux-x64-musl@1.13.0:
+    optional: true
+
+  sherif-linux-x64@1.13.0:
+    optional: true
+
+  sherif-windows-arm64@1.13.0:
+    optional: true
+
+  sherif-windows-x64@1.13.0:
+    optional: true
+
+  sherif@1.13.0:
+    optionalDependencies:
+      sherif-darwin-arm64: 1.13.0
+      sherif-darwin-x64: 1.13.0
+      sherif-linux-arm64: 1.13.0
+      sherif-linux-arm64-musl: 1.13.0
+      sherif-linux-x64: 1.13.0
+      sherif-linux-x64-musl: 1.13.0
+      sherif-windows-arm64: 1.13.0
+      sherif-windows-x64: 1.13.0
 
   siginfo@2.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,7 @@ catalogs:
     "@commitlint/cli": ^21.2.0
     "@commitlint/config-conventional": ^21.2.0
     "@commitlint/types": ^21.2.0
+    sherif: ^1.11.1
 
   # ===== MONOREPO =====
   monorepo:

--- a/tooling/github/setup/action.yml
+++ b/tooling/github/setup/action.yml
@@ -10,10 +10,6 @@ runs:
         node-version-file: ".nvmrc"
         cache: "pnpm"
 
-    - name: Install Turbo
-      shell: bash
-      run: pnpm install -g turbo
-
     - name: Install Dependencies
       shell: bash
       run: pnpm install --frozen-lockfile


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pins the workspace checker and removes a redundant global tool install. The main changes are:

- `check:ws` now runs the local `sherif` binary.
- `sherif` is added through the lint catalog and lockfile.
- The GitHub setup action no longer installs Turbo globally.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues were found in the changed code. The local `sherif` dependency is present in the catalog and lockfile, and the workflow paths use Turbo through installed pnpm scripts after dependencies are installed.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The team reviewed the general contract validation proof to confirm that the tooling validation transcript includes each command, the working directory, timestamps, and exit codes for all validation steps.
- The team verified that a runner script was generated to document and reproduce the exact commands run during tooling validation.
- The team inspected the artifact index log to confirm which artifacts were saved and to verify that the log excerpts reflect the successful validation run.

<a href="https://app.greptile.com/trex/runs/13706792/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Switches `check:ws` to the local `sherif` binary and adds `sherif` as a root devDependency. |
| pnpm-workspace.yaml | Adds `sherif` to the lint catalog. |
| pnpm-lock.yaml | Locks `sherif@1.13.0` and its platform-specific optional binary packages. |
| tooling/github/setup/action.yml | Removes the global Turbo install from the shared GitHub setup action. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: drop global turbo, pin sherif loc..."](https://github.com/ryuudotgg/forge/commit/8251d55012ee5b23476d92b3532a873b39eaa91d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42751803)</sub>

<!-- /greptile_comment -->