### PR TITLE
fix(cli): gate pm version, smoke all managers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2 # We probe test all PMs.
 
       - name: Setup
         uses: ./tooling/github/setup

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -35,7 +35,7 @@ jobs:
   smoke:
     name: Install Smoke
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     permissions:
       contents: read
 
@@ -50,5 +50,11 @@ jobs:
 
       - name: Smoke Test
         run: pnpm --filter @ryuujs/scenarios exec vitest run src/scenarios/install.smoke.test.ts
+        env:
+          FORGE_SMOKE: "1"
+
+      - name: Multi-PM Smoke
+        if: ${{ github.event_name != 'pull_request' }}
+        run: pnpm --filter @ryuujs/scenarios exec vitest run src/scenarios/multi-pm.smoke.test.ts
         env:
           FORGE_SMOKE: "1"

--- a/packages/cli/src/orchestrator.ts
+++ b/packages/cli/src/orchestrator.ts
@@ -21,7 +21,10 @@ export async function orchestrate(
 
 		const key = step.configKey === null ? null : (step.configKey ?? step.id);
 
-		if (key !== null && key in config && config[key] !== undefined) continue;
+		if (key !== null && key in config && config[key] !== undefined) {
+			await step.validate?.(config[key], config);
+			continue;
+		}
 
 		if (key === null && step.schemaShape) {
 			const shapeKeys = Object.keys(step.schemaShape);

--- a/packages/cli/src/steps/project/package-manager.ts
+++ b/packages/cli/src/steps/project/package-manager.ts
@@ -35,17 +35,27 @@ const packageManagerStep = defineStep<typeof packageManagerSchema.Type>({
 
 	shouldRun: () => true,
 
+	validate(value) {
+		const result = Schema.decodeUnknownEither(packageManagerSchema)(value);
+		if (Either.isLeft(result)) return;
+
+		const check = checkPackageManager(result.right);
+		if (!check.ok) {
+			log.error(check.message);
+			process.exit(1);
+		}
+	},
+
 	async execute(config, interactive) {
 		const smartDefault = getSmartDefault(config.runtime);
 
 		if (!interactive) {
-			if (config.packageManager) {
-				const result = Schema.decodeUnknownEither(packageManagerSchema)(
-					config.packageManager,
-				);
-
-				return Either.isRight(result) ? result.right : smartDefault;
+			const check = checkPackageManager(smartDefault);
+			if (!check.ok) {
+				log.error(check.message);
+				process.exit(1);
 			}
+
 			return smartDefault;
 		}
 

--- a/packages/cli/src/steps/types.ts
+++ b/packages/cli/src/steps/types.ts
@@ -31,6 +31,7 @@ export interface Step {
 	schemaDefault?: () => unknown;
 	dependencies?: string[];
 	shouldRun: (config: PartialConfig) => boolean;
+	validate?: (value: unknown, config: PartialConfig) => void | Promise<void>;
 	execute: (config: PartialConfig, interactive: boolean) => Promise<unknown>;
 }
 
@@ -43,6 +44,7 @@ export function defineStep<TOutput>(step: {
 	schemaDefault?: () => TOutput;
 	dependencies?: string[];
 	shouldRun: (config: PartialConfig) => boolean;
+	validate?: (value: unknown, config: PartialConfig) => void | Promise<void>;
 	execute: (
 		config: PartialConfig,
 		interactive: boolean,

--- a/packages/cli/tests/orchestrator.test.ts
+++ b/packages/cli/tests/orchestrator.test.ts
@@ -51,6 +51,48 @@ describe("orchestrate", () => {
 		expect(config.color).toBe("red");
 	});
 
+	it("awaits a step's validate hook when the config pre-supplies its key", async () => {
+		const validate = vi.fn(async () => undefined);
+		const execute = vi.fn(async () => "blue");
+		const step = makeStep({
+			id: "color",
+			configKey: "color",
+			schema: Schema.String,
+			validate,
+			execute,
+		});
+
+		const config = await orchestrate([step], {
+			interactive: false,
+			initialConfig: { color: "red" },
+		});
+
+		expect(validate).toHaveBeenCalledWith("red", { color: "red" });
+		expect(execute).not.toHaveBeenCalled();
+		expect(config.color).toBe("red");
+	});
+
+	it("skips a step's validate hook when the key is absent and runs execute", async () => {
+		const validate = vi.fn(async () => undefined);
+		const execute = vi.fn(async () => "blue");
+		const step = makeStep({
+			id: "color",
+			configKey: "color",
+			schema: Schema.String,
+			validate,
+			execute,
+		});
+
+		const config = await orchestrate([step], {
+			interactive: false,
+			initialConfig: {},
+		});
+
+		expect(validate).not.toHaveBeenCalled();
+		expect(execute).toHaveBeenCalled();
+		expect(config.color).toBe("blue");
+	});
+
 	it("stores results under the step id when no config key is given", async () => {
 		const step = makeStep({
 			id: "color",

--- a/packages/cli/tests/steps-project.test.ts
+++ b/packages/cli/tests/steps-project.test.ts
@@ -50,6 +50,7 @@ interface TextPromptOptions {
 describe("project steps", () => {
 	beforeEach(() => {
 		coreMocks.checkPackageManager.mockReset();
+		coreMocks.checkPackageManager.mockReturnValue({ ok: true, message: "ok" });
 		promptMocks.logError.mockReset();
 		promptMocks.logWarn.mockReset();
 		promptMocks.select.mockReset();
@@ -57,14 +58,6 @@ describe("project steps", () => {
 	});
 
 	describe("package manager", () => {
-		it("uses the configured package manager without prompting", async () => {
-			await expect(
-				packageManagerStep.execute({ packageManager: "npm" }, false),
-			).resolves.toBe("npm");
-
-			expect(promptMocks.select).not.toHaveBeenCalled();
-		});
-
 		it("defaults to Bun when the runtime is Bun", async () => {
 			await expect(
 				packageManagerStep.execute({ runtime: "Bun" }, false),
@@ -78,13 +71,73 @@ describe("project steps", () => {
 			await expect(packageManagerStep.execute({}, false)).resolves.toBe("pnpm");
 		});
 
-		it("silently falls back to the smart default for an invalid package manager", async () => {
+		it("validates a supplied package manager against the version gate", async () => {
 			await expect(
-				packageManagerStep.execute(
-					rawConfig({ packageManager: "yarn-classic" }),
-					false,
-				),
-			).resolves.toBe("pnpm");
+				Promise.resolve(packageManagerStep.validate?.("npm", {})),
+			).resolves.toBeUndefined();
+
+			expect(coreMocks.checkPackageManager).toHaveBeenCalledWith("npm");
+		});
+
+		it("exits from validate when the supplied package manager fails the version gate", async () => {
+			const exit = vi.spyOn(process, "exit").mockImplementation(((
+				code?: string | number | null,
+			) => {
+				throw new Error(`exit:${code ?? 0}`);
+			}) as never);
+
+			try {
+				coreMocks.checkPackageManager.mockReturnValue({
+					ok: false,
+					message:
+						"You need Yarn v4 or later to forge a project, but you're running v1.22.22.",
+				});
+
+				expect(() => packageManagerStep.validate?.("Yarn", {})).toThrow(
+					"exit:1",
+				);
+
+				expect(promptMocks.logError).toHaveBeenCalledWith(
+					"You need Yarn v4 or later to forge a project, but you're running v1.22.22.",
+				);
+			} finally {
+				exit.mockRestore();
+			}
+		});
+
+		it("leaves invalid supplied values to the schema decoder", async () => {
+			await expect(
+				Promise.resolve(packageManagerStep.validate?.("yarn-classic", {})),
+			).resolves.toBeUndefined();
+
+			expect(coreMocks.checkPackageManager).not.toHaveBeenCalled();
+			expect(promptMocks.logError).not.toHaveBeenCalled();
+		});
+
+		it("exits non-interactively when the smart default fails the version gate", async () => {
+			const exit = vi.spyOn(process, "exit").mockImplementation(((
+				code?: string | number | null,
+			) => {
+				throw new Error(`exit:${code ?? 0}`);
+			}) as never);
+
+			try {
+				coreMocks.checkPackageManager.mockReturnValue({
+					ok: false,
+					message:
+						"You don't have pnpm installed, please install it and try again.",
+				});
+
+				await expect(packageManagerStep.execute({}, false)).rejects.toThrow(
+					"exit:1",
+				);
+
+				expect(promptMocks.logError).toHaveBeenCalledWith(
+					"You don't have pnpm installed, please install it and try again.",
+				);
+			} finally {
+				exit.mockRestore();
+			}
 		});
 
 		it("marks the smart default as recommended and returns the selection", async () => {

--- a/tests/scenarios/src/scenarios/install.smoke.test.ts
+++ b/tests/scenarios/src/scenarios/install.smoke.test.ts
@@ -2,34 +2,10 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	createProject,
-	forgeEnvironment,
+	expectInstallAndTypecheck,
 	pathExists,
-	runCommand,
-	type ScenarioProject,
 	withScenarioWorkspace,
 } from "../utils/harness";
-
-async function expectTypecheckPasses(workspace: ScenarioProject) {
-	const installResult = await runCommand("pnpm", ["install"], {
-		cwd: workspace.projectRoot,
-		env: forgeEnvironment(workspace.workspaceRoot),
-	});
-
-	expect(
-		installResult.exitCode,
-		`pnpm install failed with code ${installResult.exitCode}\n${installResult.stdout}\n${installResult.stderr}`,
-	).toBe(0);
-
-	const result = await runCommand("pnpm", ["typecheck"], {
-		cwd: workspace.projectRoot,
-		env: forgeEnvironment(workspace.workspaceRoot),
-	});
-
-	expect(
-		result.exitCode,
-		`pnpm typecheck failed with code ${result.exitCode}\n${result.stdout}\n${result.stderr}`,
-	).toBe(0);
-}
 
 describe.runIf(process.env.FORGE_SMOKE === "1")("install smoke", () => {
 	it("installs a prisma project, generates the client, and typechecks", async () => {
@@ -54,7 +30,7 @@ describe.runIf(process.env.FORGE_SMOKE === "1")("install smoke", () => {
 				),
 			).toBe(true);
 
-			await expectTypecheckPasses(workspace);
+			await expectInstallAndTypecheck(workspace, "pnpm");
 		});
 	}, 600_000);
 
@@ -75,7 +51,7 @@ describe.runIf(process.env.FORGE_SMOKE === "1")("install smoke", () => {
 				{ install: true },
 			);
 
-			await expectTypecheckPasses(workspace);
+			await expectInstallAndTypecheck(workspace, "pnpm");
 		});
 	}, 600_000);
 
@@ -96,7 +72,7 @@ describe.runIf(process.env.FORGE_SMOKE === "1")("install smoke", () => {
 				{ install: true },
 			);
 
-			await expectTypecheckPasses(workspace);
+			await expectInstallAndTypecheck(workspace, "pnpm");
 		});
 	}, 600_000);
 
@@ -117,7 +93,7 @@ describe.runIf(process.env.FORGE_SMOKE === "1")("install smoke", () => {
 				{ install: true },
 			);
 
-			await expectTypecheckPasses(workspace);
+			await expectInstallAndTypecheck(workspace, "pnpm");
 		});
 	}, 600_000);
 });

--- a/tests/scenarios/src/scenarios/multi-pm.smoke.test.ts
+++ b/tests/scenarios/src/scenarios/multi-pm.smoke.test.ts
@@ -1,0 +1,71 @@
+import { describe, it } from "vitest";
+import {
+	createProject,
+	expectInstallAndTypecheck,
+	withScenarioWorkspace,
+} from "../utils/harness";
+
+describe.runIf(process.env.FORGE_SMOKE === "1")("multi-pm smoke", () => {
+	it("installs and typechecks a bun project", async () => {
+		await withScenarioWorkspace("smoke-bun", async (workspace) => {
+			await createProject(
+				workspace,
+				{
+					authentication: "better-auth",
+					database: "postgresql",
+					linter: "biome",
+					orm: "drizzle",
+					packageManager: "Bun",
+					rpc: "trpc",
+					style: "tailwind",
+					web: "nextjs",
+				},
+				{ install: true },
+			);
+
+			await expectInstallAndTypecheck(workspace, "bun");
+		});
+	}, 600_000);
+
+	it("installs and typechecks a yarn project", async () => {
+		await withScenarioWorkspace("smoke-yarn", async (workspace) => {
+			await createProject(
+				workspace,
+				{
+					authentication: "better-auth",
+					database: "postgresql",
+					linter: "biome",
+					orm: "drizzle",
+					packageManager: "Yarn",
+					rpc: "trpc",
+					style: "tailwind",
+					web: "nextjs",
+				},
+				{ install: true },
+			);
+
+			await expectInstallAndTypecheck(workspace, "yarn");
+		});
+	}, 600_000);
+
+	it("installs and typechecks an npm project", async () => {
+		await withScenarioWorkspace("smoke-npm", async (workspace) => {
+			await createProject(
+				workspace,
+				{
+					authentication: "better-auth",
+					database: "postgresql",
+					linter: "biome",
+					orm: "drizzle",
+					packageManager: "npm",
+					rpc: "trpc",
+					style: "tailwind",
+					web: "nextjs",
+				},
+				{ install: true },
+			);
+
+			await expectInstallAndTypecheck(workspace, "npm");
+		});
+	}, 600_000);
+});

--- a/tests/scenarios/src/utils/harness.ts
+++ b/tests/scenarios/src/utils/harness.ts
@@ -8,8 +8,9 @@ import {
 	rm,
 	writeFile,
 } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { expect } from "vitest";
 
 const forgeCliPath = resolve(
 	process.cwd(),
@@ -36,6 +37,9 @@ export function forgeEnvironment(workspaceRoot: string): NodeJS.ProcessEnv {
 	const cacheRoot = join(workspaceRoot, ".cache");
 
 	return {
+		COREPACK_HOME:
+			process.env.COREPACK_HOME ??
+			join(homedir(), ".cache", "node", "corepack"),
 		FORGE_CACHE_DIR: join(cacheRoot, "forge"),
 		XDG_CACHE_HOME: join(cacheRoot, "xdg"),
 	};
@@ -230,6 +234,51 @@ export async function updateProject(
 		env: options?.env,
 		workspaceRoot: dirname(projectRoot),
 	});
+}
+
+const installArgsFor: Record<
+	"pnpm" | "npm" | "yarn" | "bun",
+	ReadonlyArray<string>
+> = {
+	bun: ["install"],
+	npm: ["install"],
+	pnpm: ["install"],
+	yarn: ["install"],
+};
+
+const typecheckArgsFor: Record<
+	"pnpm" | "npm" | "yarn" | "bun",
+	ReadonlyArray<string>
+> = {
+	bun: ["run", "typecheck"],
+	npm: ["run", "typecheck"],
+	pnpm: ["typecheck"],
+	yarn: ["typecheck"],
+};
+
+export async function expectInstallAndTypecheck(
+	workspace: ScenarioProject,
+	pm: "pnpm" | "npm" | "yarn" | "bun",
+) {
+	const installResult = await runCommand(pm, installArgsFor[pm], {
+		cwd: workspace.projectRoot,
+		env: forgeEnvironment(workspace.workspaceRoot),
+	});
+
+	expect(
+		installResult.exitCode,
+		`${pm} install failed with code ${installResult.exitCode}\n${installResult.stdout}\n${installResult.stderr}`,
+	).toBe(0);
+
+	const result = await runCommand(pm, typecheckArgsFor[pm], {
+		cwd: workspace.projectRoot,
+		env: forgeEnvironment(workspace.workspaceRoot),
+	});
+
+	expect(
+		result.exitCode,
+		`${pm} typecheck failed with code ${result.exitCode}\n${result.stdout}\n${result.stderr}`,
+	).toBe(0);
 }
 
 export async function renameModuleRoot(

--- a/tooling/github/setup/action.yml
+++ b/tooling/github/setup/action.yml
@@ -10,6 +10,14 @@ runs:
         node-version-file: ".nvmrc"
         cache: "pnpm"
 
+    - uses: oven-sh/setup-bun@v2
+
+    - name: Setup Yarn
+      shell: bash
+      run: |
+        corepack enable
+        corepack install -g yarn@stable
+
     - name: Install Dependencies
       shell: bash
       run: pnpm install --frozen-lockfile


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds package-manager validation and broader smoke coverage for generated projects. The main changes are:

- Validates pre-supplied package-manager config through a new step `validate` hook.
- Gates selected or default package managers on local availability and minimum versions.
- Adds Bun, Yarn, and npm smoke scenarios alongside the existing pnpm install smoke tests.
- Moves Bun and Yarn setup into the shared GitHub setup action.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are focused, covered by targeted unit tests and smoke scenarios, and no correctness or security issues were identified in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the environment details were captured by recording package manager versions used in the run in trex-artifacts/pm-versions.log.
- Confirmed that built dist outputs were generated, as shown in trex-artifacts/dist-check.log.
- Executed the scenario smoke test and documented the exact smoke command and the final Vitest summary, including the counts and exit code, in trex-artifacts/scenario-smoke.log.
- Validated environment-blocker handling by locating the Yarn version message indicating v4+ is required, which appeared as You need Yarn v4 or later to forge a project, but you're running v1.22.22, in the test outputs.

<a href="https://app.greptile.com/trex/runs/14918771/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/smoke.yml | Extends smoke test timeout and adds a non-PR multi-package-manager smoke suite. |
| packages/cli/src/orchestrator.ts | Adds support for awaiting step-level validation when an initial config already supplies the step key. |
| packages/cli/src/steps/project/package-manager.ts | Adds package-manager version gating for supplied configs and smart non-interactive defaults. |
| tests/scenarios/src/scenarios/multi-pm.smoke.test.ts | Adds smoke scenarios for Bun, Yarn, and npm generated projects. |
| tests/scenarios/src/utils/harness.ts | Adds shared package-manager-specific install/typecheck assertions and preserves Corepack cache access. |
| tooling/github/setup/action.yml | Moves Bun and Yarn setup into the shared GitHub composite setup action. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant UserConfig as Pre-supplied config
participant Orchestrator as CLI orchestrator
participant Step as Package manager step
participant Env as checkPackageManager
participant Smoke as Smoke CI

UserConfig->>Orchestrator: packageManager value
Orchestrator->>Step: validate(value, config)
Step->>Step: decode packageManager schema
Step->>Env: check selected package manager version
alt package manager is usable
    Env-->>Step: ok
    Step-->>Orchestrator: continue without execute
else missing or below minimum version
    Env-->>Step: error message
    Step-->>Orchestrator: log error and exit(1)
end
Smoke->>Smoke: install/typecheck generated projects with pnpm, Bun, Yarn, npm
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant UserConfig as Pre-supplied config
participant Orchestrator as CLI orchestrator
participant Step as Package manager step
participant Env as checkPackageManager
participant Smoke as Smoke CI

UserConfig->>Orchestrator: packageManager value
Orchestrator->>Step: validate(value, config)
Step->>Step: decode packageManager schema
Step->>Env: check selected package manager version
alt package manager is usable
    Env-->>Step: ok
    Step-->>Orchestrator: continue without execute
else missing or below minimum version
    Env-->>Step: error message
    Step-->>Orchestrator: log error and exit(1)
end
Smoke->>Smoke: install/typecheck generated projects with pnpm, Bun, Yarn, npm
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): gate pm version, smoke all man..."](https://github.com/ryuudotgg/forge/commit/917df1ace7f63dbdaa2c27b25fb52c74c8a513e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45247456)</sub>

<!-- /greptile_comment -->