### PR TITLE
fix: disable yarn immutable installs in scenarios

### DIFF
--- a/tests/scenarios/src/utils/harness.ts
+++ b/tests/scenarios/src/utils/harness.ts
@@ -42,6 +42,9 @@ export function forgeEnvironment(workspaceRoot: string): NodeJS.ProcessEnv {
 			join(homedir(), ".cache", "node", "corepack"),
 		FORGE_CACHE_DIR: join(cacheRoot, "forge"),
 		XDG_CACHE_HOME: join(cacheRoot, "xdg"),
+		// Yarn defaults to immutable installs when CI is set, but scenario
+		// installs create the lockfile for freshly scaffolded projects.
+		YARN_ENABLE_IMMUTABLE_INSTALLS: "0",
 	};
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the scenario test harness environment for Yarn installs. The main change is:

- Disables Yarn immutable installs with `YARN_ENABLE_IMMUTABLE_INSTALLS=0` so freshly scaffolded scenario projects can create lockfiles under `CI=true`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to scenario-test environment variables and matches the existing flow that runs installs for newly created projects with `CI=true`.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The harness environment check was executed and the after-log confirmed YARN\_ENABLE\_IMMUTABLE\_INSTALLS equals "0", cache directories and XDG\_CACHE\_HOME under the generated workspace .cache, and the process exited with code 0.
- The scenarios package typecheck step was run via pnpm with a filter for @ryuujs/scenarios, invoking tsc --noEmit, and it completed with exit code 0.
- A runtime harness validation script named harness-env-validation.mjs was generated and used as part of the harness check.

<a href="https://app.greptile.com/trex/runs/14953623/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/scenarios/src/utils/harness.ts | Adds `YARN_ENABLE_IMMUTABLE_INSTALLS=0` to the scenario test environment so Yarn installs can generate lockfiles under CI. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: disable yarn immutable installs in ..."](https://github.com/ryuudotgg/forge/commit/42b5a81201d08301b0c15bffb91e50d5b9aaac94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45325558)</sub>

<!-- /greptile_comment -->