### PR TITLE
refactor(core): share the content hash helper

### DIFF
--- a/packages/core/src/apply.ts
+++ b/packages/core/src/apply.ts
@@ -3,6 +3,7 @@ import { dirname, join, resolve, sep } from "node:path";
 import { FileSystem } from "@effect/platform";
 import { Effect } from "effect";
 import { ApplyError } from "./errors";
+import { hashContentHex } from "./hash";
 import type { Lockfile, Manifest } from "./state";
 import { buildArtifactIndex, State } from "./state";
 
@@ -59,21 +60,14 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 		const hashContent = Effect.fn("Apply.hashContent")(function* (
 			content: string,
 		) {
-			const encoder = new TextEncoder();
-			const data = encoder.encode(content);
-
-			const buffer = yield* Effect.tryPromise({
-				try: () => globalThis.crypto.subtle.digest("SHA-256", data),
-				catch: () =>
+			return yield* hashContentHex(
+				content,
+				() =>
 					new ApplyError({
 						path: "content",
 						message: "Content Hash Failed",
 					}),
-			});
-
-			return Array.from(new Uint8Array(buffer))
-				.map((byte) => byte.toString(16).padStart(2, "0"))
-				.join("");
+			);
 		});
 
 		const applyPlan = Effect.fn("Apply.applyPlan")(function* (

--- a/packages/core/src/hash.ts
+++ b/packages/core/src/hash.ts
@@ -1,0 +1,19 @@
+import { Effect } from "effect";
+
+export function hashContentHex<E>(
+	content: string,
+	onError: () => E,
+): Effect.Effect<string, E> {
+	const data = new TextEncoder().encode(content);
+
+	return Effect.tryPromise({
+		try: () => globalThis.crypto.subtle.digest("SHA-256", data),
+		catch: onError,
+	}).pipe(
+		Effect.map((buffer) =>
+			Array.from(new Uint8Array(buffer))
+				.map((byte) => byte.toString(16).padStart(2, "0"))
+				.join(""),
+		),
+	);
+}

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -8,6 +8,7 @@ import {
 	PipelineError,
 } from "./errors";
 import type { Generator } from "./generator";
+import { hashContentHex } from "./hash";
 import { Registry } from "./registry";
 import type { ResolvedFile } from "./virtual-fs";
 import { Vfs } from "./virtual-fs";
@@ -180,21 +181,14 @@ export class Pipeline extends Effect.Service<Pipeline>()("Pipeline", {
 		const hashContent = Effect.fn("Pipeline.hashContent")(function* (
 			content: string,
 		) {
-			const encoder = new TextEncoder();
-			const data = encoder.encode(content);
-
-			const buffer = yield* Effect.tryPromise({
-				try: () => globalThis.crypto.subtle.digest("SHA-256", data),
-				catch: () =>
+			return yield* hashContentHex(
+				content,
+				() =>
 					new PipelineError({
 						path: "content",
 						message: "Content Hash Failed",
 					}),
-			});
-
-			return Array.from(new Uint8Array(buffer))
-				.map((byte) => byte.toString(16).padStart(2, "0"))
-				.join("");
+			);
 		});
 
 		return { hashContent, run };

--- a/packages/core/src/planner.ts
+++ b/packages/core/src/planner.ts
@@ -18,6 +18,7 @@ import {
 import { dependencyFormatFor } from "./environment";
 import { AggregateConflictError, GeneratorError, PlannerError } from "./errors";
 import { formatJson } from "./format/json";
+import { hashContentHex } from "./hash";
 import { type FileOperation, filePath } from "./operations";
 import {
 	type RenderBucket,
@@ -849,21 +850,14 @@ export class Planner extends Effect.Service<Planner>()("Planner", {
 		const hashString = Effect.fn("Planner.hashString")(function* (
 			content: string,
 		) {
-			const encoder = new TextEncoder();
-			const data = encoder.encode(content);
-
-			const buffer = yield* Effect.tryPromise({
-				try: () => globalThis.crypto.subtle.digest("SHA-256", data),
-				catch: () =>
+			return yield* hashContentHex(
+				content,
+				() =>
 					new PlannerError({
 						path: "content",
 						message: "Content Hash Failed",
 					}),
-			});
-
-			return Array.from(new Uint8Array(buffer))
-				.map((byte) => byte.toString(16).padStart(2, "0"))
-				.join("");
+			);
 		});
 
 		const buildLockfile = Effect.fn("Planner.buildLockfile")(function* (

--- a/packages/core/tests/hash.test.ts
+++ b/packages/core/tests/hash.test.ts
@@ -1,0 +1,33 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { hashContentHex } from "../src/hash";
+
+interface HashError {
+	readonly message: string;
+}
+
+function contentHashFailed(): HashError {
+	return { message: "Content Hash Failed" };
+}
+
+describe("hash", () => {
+	it("hashes an empty string with SHA-256", async () => {
+		const result = await Effect.runPromise(
+			hashContentHex("", contentHashFailed),
+		);
+
+		expect(result).toBe(
+			"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		);
+	});
+
+	it("hashes hello with SHA-256", async () => {
+		const result = await Effect.runPromise(
+			hashContentHex("hello", contentHashFailed),
+		);
+
+		expect(result).toBe(
+			"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+		);
+	});
+});


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts shared SHA-256 content hashing into a reusable core helper. The main changes are:

- Added `hashContentHex` for Effect-based SHA-256 hex digest generation.
- Replaced duplicated hashing logic in apply, pipeline, and planner code paths.
- Kept caller-specific error mapping for `ApplyError`, `PipelineError`, and `PlannerError`.
- Added tests for known SHA-256 outputs.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is a small refactor that preserves the previous hashing behavior and caller-specific error mapping. Tests cover known SHA-256 outputs for representative inputs.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Captured the targeted Vitest command, working directory, output, and exit code in core-hash-01-before.log.
- Performed the runtime cross-check of per-case actual vs. expected hashes and recorded the results in core-hash-02-after.log, including a verification summary and exit code.
- Generated the runtime cross-check script core-hash-crosscheck.mjs used for direct hash comparison.

<a href="https://app.greptile.com/trex/runs/14956525/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/hash.ts | Adds a shared Effect-based SHA-256 hex digest helper parameterized by caller-specific error construction. |
| packages/core/src/apply.ts | Replaces local SHA-256 content hashing with the shared helper while preserving `ApplyError` mapping. |
| packages/core/src/pipeline.ts | Reuses the shared content hash helper for pipeline hashing while preserving `PipelineError` behavior. |
| packages/core/src/planner.ts | Reuses the shared content hash helper for planner lockfile hashing while preserving `PlannerError` behavior. |
| packages/core/tests/hash.test.ts | Adds tests confirming the shared helper returns known SHA-256 hex digests for representative inputs. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Caller as Apply/Pipeline/Planner
participant Hash as hashContentHex
participant Crypto as globalThis.crypto.subtle
Caller->>Hash: content + error factory
Hash->>Crypto: digest("SHA-256", encoded content)
Crypto-->>Hash: ArrayBuffer digest
Hash-->>Caller: lowercase hex string
alt digest failure
    Hash-->>Caller: caller-specific Effect error
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Caller as Apply/Pipeline/Planner
participant Hash as hashContentHex
participant Crypto as globalThis.crypto.subtle
Caller->>Hash: content + error factory
Hash->>Crypto: digest("SHA-256", encoded content)
Crypto-->>Hash: ArrayBuffer digest
Hash-->>Caller: lowercase hex string
alt digest failure
    Hash-->>Caller: caller-specific Effect error
end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(core): share the content hash h..."](https://github.com/ryuudotgg/forge/commit/d1aa67d8049d9b1e577554ec7d857d76aec8d527) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45331251)</sub>

<!-- /greptile_comment -->