### PR TITLE
test: cover command probe failure branches

### DIFF
--- a/packages/core/tests/command.test.ts
+++ b/packages/core/tests/command.test.ts
@@ -1,0 +1,45 @@
+import { Effect } from "effect";
+import { describe, expect, it, vi } from "vitest";
+import { CommandProbe } from "../src/command";
+
+vi.mock("node:child_process", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:child_process")>();
+	return {
+		...actual,
+		execFileSync: (...args: Parameters<typeof actual.execFileSync>) => {
+			if (args[0] === "forge-test-non-error-4242") {
+				throw "plain failure string";
+			}
+			return actual.execFileSync(...args);
+		},
+	};
+});
+
+describe("CommandProbe", () => {
+	it("maps a missing binary to a CommandProbeError", async () => {
+		const error = await Effect.runPromise(
+			CommandProbe.readVersion("forge-test-missing-binary-4242").pipe(
+				Effect.flip,
+				Effect.provide(CommandProbe.Default),
+			),
+		);
+
+		expect(error._tag).toBe("CommandProbeError");
+		expect(error.command).toBe("forge-test-missing-binary-4242");
+		expect(error.message).toContain("Command Probe Failed");
+		expect(error.detail.length).toBeGreaterThan(0);
+	});
+
+	it("maps a non-Error failure to a CommandProbeError", async () => {
+		const error = await Effect.runPromise(
+			CommandProbe.readVersion("forge-test-non-error-4242").pipe(
+				Effect.flip,
+				Effect.provide(CommandProbe.Default),
+			),
+		);
+
+		expect(error._tag).toBe("CommandProbeError");
+		expect(error.command).toBe("forge-test-non-error-4242");
+		expect(error.detail).toBe("plain failure string");
+	});
+});


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds tests for `CommandProbe` failure handling. The main changes are:

- Covers missing binary failures being mapped to `CommandProbeError`.
- Covers non-`Error` thrown values being converted into `CommandProbeError.detail`.
- Uses a targeted `execFileSync` mock for the non-`Error` failure branch.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to a new test file that exercises existing error branches. The `execFileSync` mock preserves actual behavior except for the targeted sentinel command.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the command-probe tests using Vitest against the current checkout.
- The command invocation, including its working directory and exit code, was captured in the attached artifact.
- Vitest reported both CommandProbe failure-branch tests passed against the checkout.

<a href="https://app.greptile.com/trex/runs/14982982/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/tests/command.test.ts | Adds focused tests for `CommandProbe.readVersion` error mapping for missing binaries and non-`Error` throws; no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover command probe failure branch..."](https://github.com/ryuudotgg/forge/commit/6fbae8221efecdc1d5b69649c1f0fdde1e3a7113) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45386760)</sub>

<!-- /greptile_comment -->