### PR TITLE
fix(trpc): wire auth session into context

### DIFF
--- a/packages/generators/src/api/trpc/index.ts
+++ b/packages/generators/src/api/trpc/index.ts
@@ -27,23 +27,46 @@ const trpc = defineAddon<ForgeConfig, "trpc", "nextjs">({
 		const slug = config.slug ?? "my-app";
 
 		const usesDb = config.orm !== undefined;
+		const usesAuth = config.authentication === "better-auth";
 		const vars = {
 			SLUG: slug,
 			DB_IMPORT: usesDb ? `import { db } from "@${slug}/db/client";\n` : "",
 			DB_CTX_TYPE: usesDb ? "\n  db: typeof db;" : "",
 			DB_CTX_VALUE: usesDb ? " db," : "",
+			AUTH_TYPE_IMPORT: usesAuth
+				? `import type { Auth } from "@${slug}/auth";\n`
+				: "",
+			AUTH_IMPORT: usesAuth ? `import { auth } from "@${slug}/auth";\n` : "",
+			SESSION_TYPE: usesAuth
+				? 'Awaited<ReturnType<Auth["api"]["getSession"]>>'
+				: "{ user: { id: string; email: string } } | null",
+			CTX_AUTH_PARAM: usesAuth ? "auth: Auth;\n  " : "",
+			SESSION_RESOLVE: usesAuth
+				? "const session = await opts.auth.api.getSession({ headers: opts.headers });"
+				: "const session = null;",
+			AUTH_ARG: usesAuth ? "auth, " : "",
 		};
 
 		const render = (path: string) =>
 			interpolate(readTemplate(`api/trpc/${path}`), vars);
 
-		const dbDeps: Array<{
+		const moduleDeps: Array<{
 			name: string;
 			version: string;
 			type: "dependencies";
-		}> = usesDb
-			? [{ name: `@${slug}/db`, version: "workspace:*", type: "dependencies" }]
-			: [];
+		}> = [];
+		if (usesDb)
+			moduleDeps.push({
+				name: `@${slug}/db`,
+				version: "workspace:*",
+				type: "dependencies",
+			});
+		if (usesAuth)
+			moduleDeps.push({
+				name: `@${slug}/auth`,
+				version: "workspace:*",
+				type: "dependencies",
+			});
 
 		return [
 			ensurePackageModule("trpc", "packages/trpc", {
@@ -69,7 +92,7 @@ const trpc = defineAddon<ForgeConfig, "trpc", "nextjs">({
 				exclude: ["node_modules"],
 			}),
 			surfaceDependencies(ensuredModuleTarget("trpc"), "packageJson", [
-				...dbDeps,
+				...moduleDeps,
 				{ ...deps.trpcServer, type: "dependencies" },
 				{ ...deps.superjson, type: "dependencies" },
 				{ ...deps.zod, type: "dependencies" },

--- a/packages/generators/templates/api/trpc/apps/web/app/api/trpc/[trpc]/route.ts
+++ b/packages/generators/templates/api/trpc/apps/web/app/api/trpc/[trpc]/route.ts
@@ -1,11 +1,11 @@
 import { appRouter, createTRPCContext } from "@__SLUG__/trpc";
-import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+__AUTH_IMPORT__import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import type { NextRequest } from "next/server";
 
 function createContext(req: NextRequest) {
   const headers = new Headers(req.headers);
   headers.set("x-trpc-source", "route");
-  return createTRPCContext({ headers, session: null });
+  return createTRPCContext({ __AUTH_ARG__headers });
 }
 
 function handler(req: NextRequest) {

--- a/packages/generators/templates/api/trpc/apps/web/trpc/server.ts
+++ b/packages/generators/templates/api/trpc/apps/web/trpc/server.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import type { AppRouter } from "@__SLUG__/trpc";
 import { createCaller, createTRPCContext } from "@__SLUG__/trpc";
-import { createHydrationHelpers } from "@trpc/react-query/rsc";
+__AUTH_IMPORT__import { createHydrationHelpers } from "@trpc/react-query/rsc";
 import { headers } from "next/headers";
 import { cache } from "react";
 
@@ -12,7 +12,7 @@ const createContext = cache(async () => {
   const heads = new Headers(await headers());
   heads.set("x-trpc-source", "rsc");
 
-  return createTRPCContext({ headers: heads, session: null });
+  return createTRPCContext({ __AUTH_ARG__headers: heads });
 });
 
 const getQueryClient = cache(createQueryClient);

--- a/packages/generators/templates/api/trpc/packages/trpc/src/trpc.ts
+++ b/packages/generators/templates/api/trpc/packages/trpc/src/trpc.ts
@@ -1,21 +1,19 @@
-__DB_IMPORT__import { initTRPC, TRPCError } from "@trpc/server";
+__DB_IMPORT____AUTH_TYPE_IMPORT__import { initTRPC, TRPCError } from "@trpc/server";
 import SuperJSON from "superjson";
 import { ZodError, z } from "zod";
 
-type Session = {
-  user: { id: string; email: string };
-};
+type Session = __SESSION_TYPE__;
 
 type TRPCContext = {__DB_CTX_TYPE__
   headers: Headers;
-  session: Session | null;
+  session: Session;
 };
 
 export async function createTRPCContext(opts: {
-  headers: Headers;
-  session: Session | null;
+  __CTX_AUTH_PARAM__headers: Headers;
 }): Promise<TRPCContext> {
-  return {__DB_CTX_VALUE__ headers: opts.headers, session: opts.session };
+  __SESSION_RESOLVE__
+  return {__DB_CTX_VALUE__ headers: opts.headers, session };
 }
 
 const t = initTRPC.context<TRPCContext>().create({

--- a/packages/generators/tests/addons.test.ts
+++ b/packages/generators/tests/addons.test.ts
@@ -228,7 +228,7 @@ describe("trpc addon", () => {
 		expect(trpcFile.content).toContain('import { db } from "@acme/db/client";');
 		expect(trpcFile.content).toContain("db: typeof db;");
 		expect(trpcFile.content).toContain(
-			"return { db, headers: opts.headers, session: opts.session };",
+			"return { db, headers: opts.headers, session };",
 		);
 
 		const dependencies = moduleDependencySurface(contributions, "trpc");

--- a/packages/generators/tests/trpc.test.ts
+++ b/packages/generators/tests/trpc.test.ts
@@ -1,0 +1,109 @@
+import type { Contribution } from "@ryuujs/core";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import type { ForgeConfig } from "../src";
+import { trpc } from "../src";
+
+function contributionsFor(config: ForgeConfig): ReadonlyArray<Contribution> {
+	const result = trpc.contribute({ config });
+	if (result instanceof Promise || Effect.isEffect(result))
+		throw new Error("Synchronous Contributions Expected: trpc");
+	return result;
+}
+
+function leafFile(
+	contributions: ReadonlyArray<Contribution>,
+	moduleKey: string,
+	path: string,
+) {
+	const found = contributions.find(
+		(
+			contribution,
+		): contribution is Extract<
+			Contribution,
+			{ _tag: "LeafTextFileContribution" }
+		> =>
+			contribution._tag === "LeafTextFileContribution" &&
+			contribution.target._tag === "EnsuredModuleTarget" &&
+			contribution.target.moduleKey === moduleKey &&
+			contribution.path === path,
+	);
+	if (found === undefined)
+		throw new Error(`Missing Leaf File: ${moduleKey}/${path}`);
+
+	return found.content;
+}
+
+function trpcDependencyNames(contributions: ReadonlyArray<Contribution>) {
+	const found = contributions.find(
+		(
+			contribution,
+		): contribution is Extract<
+			Contribution,
+			{ _tag: "ManagedDependenciesSurfaceContribution" }
+		> =>
+			contribution._tag === "ManagedDependenciesSurfaceContribution" &&
+			contribution.target._tag === "EnsuredModuleTarget" &&
+			contribution.target.moduleKey === "trpc" &&
+			contribution.surface === "packageJson",
+	);
+	if (found === undefined) throw new Error("Missing Dependencies: trpc");
+
+	return found.dependencies.map((dependency) => dependency.name);
+}
+
+const baseConfig: ForgeConfig = { orm: "drizzle", rpc: "trpc", slug: "acme" };
+
+describe("trpc auth context", () => {
+	it("resolves and passes the full better-auth session when auth is active", () => {
+		const contributions = contributionsFor({
+			...baseConfig,
+			authentication: "better-auth",
+		});
+
+		const trpcFile = leafFile(contributions, "trpc", "src/trpc.ts");
+		expect(trpcFile).toContain('import type { Auth } from "@acme/auth";');
+		expect(trpcFile).toContain(
+			'Awaited<ReturnType<Auth["api"]["getSession"]>>',
+		);
+		expect(trpcFile).toContain("opts.auth.api.getSession");
+		expect(trpcFile).not.toContain("session: null");
+
+		const route = leafFile(
+			contributions,
+			"web",
+			"app/api/trpc/[trpc]/route.ts",
+		);
+		expect(route).toContain('import { auth } from "@acme/auth";');
+		expect(route).toContain("createTRPCContext({ auth, headers })");
+
+		const server = leafFile(contributions, "web", "trpc/server.ts");
+		expect(server).toContain('import { auth } from "@acme/auth";');
+		expect(server).toContain("createTRPCContext({ auth, headers: heads })");
+
+		expect(trpcDependencyNames(contributions)).toContain("@acme/auth");
+	});
+
+	it("keeps auth out of the context when auth is inactive", () => {
+		const contributions = contributionsFor(baseConfig);
+
+		const trpcFile = leafFile(contributions, "trpc", "src/trpc.ts");
+		expect(trpcFile).toContain("const session = null;");
+		expect(trpcFile).not.toContain("@acme/auth");
+		expect(trpcFile).not.toContain("getSession");
+
+		const route = leafFile(
+			contributions,
+			"web",
+			"app/api/trpc/[trpc]/route.ts",
+		);
+		expect(route).not.toContain("@acme/auth");
+		expect(route).toContain("createTRPCContext({ headers })");
+
+		const server = leafFile(contributions, "web", "trpc/server.ts");
+		expect(server).not.toContain("@acme/auth");
+		expect(server).toContain("createTRPCContext({ headers: heads })");
+
+		expect(trpcDependencyNames(contributions)).not.toContain("@acme/auth");
+	});
+});


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires better-auth sessions into the generated tRPC context. The main changes are:

- Adds auth-aware interpolation variables to the tRPC generator.
- Passes the generated `auth` instance from route and RSC tRPC callers.
- Resolves the session inside `createTRPCContext` from request headers.
- Surfaces the `@acme/auth` workspace dependency when better-auth is enabled.
- Adds tests for auth-enabled and auth-disabled generated output.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are localized to generator interpolation and templates. The non-auth path is preserved. Tests cover the new auth-enabled and auth-disabled output.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The generators package test suite ran and completed successfully, showing 13 test files and 152 tests passing.
- A focused verbose test run validated the TRPC auth context behavior, including the named tests 'resolves and passes the full better-auth session when auth is active' and 'keeps auth out of the context when auth is inactive', and completed with exit code 0.
- The generators package typechecking completed successfully with exit code 0.

<a href="https://app.greptile.com/trex/runs/15105463/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/generators/src/api/trpc/index.ts | Adds better-auth-aware interpolation variables and surfaces `@slug/auth` as a tRPC package dependency when authentication is enabled. |
| packages/generators/templates/api/trpc/packages/trpc/src/trpc.ts | Resolves the session inside `createTRPCContext` from better-auth headers while preserving null sessions for unauthenticated configurations. |
| packages/generators/templates/api/trpc/apps/web/app/api/trpc/[trpc]/route.ts | Updates the tRPC route context creation to pass the generated auth instance when better-auth is configured. |
| packages/generators/templates/api/trpc/apps/web/trpc/server.ts | Updates the RSC tRPC server helper to pass request headers and auth into the generated tRPC context. |
| packages/generators/tests/trpc.test.ts | Adds coverage for generated tRPC auth imports, context calls, session resolution, and dependency surfacing in both auth-enabled and auth-disabled configurations. |
| packages/generators/tests/addons.test.ts | Adjusts existing db-context expectations to match the new internally resolved session variable. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Client as tRPC caller
  participant Web as Next.js route/RSC helper
  participant Ctx as createTRPCContext
  participant Auth as better-auth
  participant Router as appRouter

  Client->>Web: Request with headers/cookies
  Web->>Web: Copy headers and set x-trpc-source
  alt better-auth enabled
    Web->>Ctx: "createTRPCContext({ auth, headers })"
    Ctx->>Auth: "auth.api.getSession({ headers })"
    Auth-->>Ctx: session or null
  else auth disabled
    Web->>Ctx: "createTRPCContext({ headers })"
    Ctx-->>Ctx: "session = null"
  end
  Ctx-->>Web: "{ headers, session, db? }"
  Web->>Router: Execute procedure with context
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Client as tRPC caller
  participant Web as Next.js route/RSC helper
  participant Ctx as createTRPCContext
  participant Auth as better-auth
  participant Router as appRouter

  Client->>Web: Request with headers/cookies
  Web->>Web: Copy headers and set x-trpc-source
  alt better-auth enabled
    Web->>Ctx: "createTRPCContext({ auth, headers })"
    Ctx->>Auth: "auth.api.getSession({ headers })"
    Auth-->>Ctx: session or null
  else auth disabled
    Web->>Ctx: "createTRPCContext({ headers })"
    Ctx-->>Ctx: "session = null"
  end
  Ctx-->>Web: "{ headers, session, db? }"
  Web->>Router: Execute procedure with context
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trpc): wire auth session into contex..."](https://github.com/ryuudotgg/forge/commit/3baccb183ca48197951e7ad5985f3a644e0cb9c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45668385)</sub>

<!-- /greptile_comment -->