### PR TITLE
fix(cli): validate config before generation

### DIFF
--- a/packages/cli/src/orchestrator.ts
+++ b/packages/cli/src/orchestrator.ts
@@ -16,44 +16,72 @@ export async function orchestrate(
 	const { interactive } = options;
 	const config: PartialConfig = { ...options.initialConfig };
 
-	for (const step of steps) {
-		if (!step.shouldRun(config)) continue;
+	const runSteps = async (stepsToRun: Step[]) => {
+		for (const step of stepsToRun) {
+			if (!step.shouldRun(config)) continue;
 
-		const key = step.configKey === null ? null : (step.configKey ?? step.id);
+			const key = step.configKey === null ? null : (step.configKey ?? step.id);
 
-		if (key !== null && key in config && config[key] !== undefined) {
-			await step.validate?.(config[key], config);
-			continue;
-		}
-
-		if (key === null && step.schemaShape) {
-			const shapeKeys = Object.keys(step.schemaShape);
-			if (shapeKeys.every((k) => k in config && config[k] !== undefined))
+			if (key !== null && key in config && config[key] !== undefined) {
+				await step.validate?.(config[key], config);
 				continue;
+			}
+
+			if (key === null && step.schemaShape) {
+				const shapeKeys = Object.keys(step.schemaShape);
+				if (shapeKeys.every((k) => k in config && config[k] !== undefined))
+					continue;
+			}
+
+			const result = await step.execute(config, interactive);
+			if (result === SKIP || result === undefined) continue;
+
+			if (key === null) Object.assign(config, result);
+			else config[key] = result;
+		}
+	};
+
+	const decodeConfig = () => {
+		const schema = assembleSchema(steps);
+		const result = Schema.decodeUnknownEither(schema)(config);
+
+		if (Either.isLeft(result)) {
+			const issues = ArrayFormatter.formatErrorSync(result.left);
+			const message = issues
+				.map((i) =>
+					i.path.length > 0
+						? `  ${i.path.join(".")}: ${i.message}`
+						: `  ${i.message}`,
+				)
+				.join("\n");
+
+			throw new Error(`Invalid Configuration:\n${message}`);
 		}
 
-		const result = await step.execute(config, interactive);
-		if (result === SKIP || result === undefined) continue;
+		return result.right;
+	};
 
-		if (key === null) Object.assign(config, result);
-		else config[key] = result;
-	}
+	const sideEffectingStepIds = new Set([
+		"generate",
+		"installDeps",
+		"gitInit",
+		"outro",
+	]);
 
-	const schema = assembleSchema(steps);
-	const result = Schema.decodeUnknownEither(schema)(config);
+	const preSideEffectSteps = steps.filter(
+		(step) => !sideEffectingStepIds.has(step.id),
+	);
 
-	if (Either.isLeft(result)) {
-		const issues = ArrayFormatter.formatErrorSync(result.left);
-		const message = issues
-			.map((i) =>
-				i.path.length > 0
-					? `  ${i.path.join(".")}: ${i.message}`
-					: `  ${i.message}`,
-			)
-			.join("\n");
+	const sideEffectingSteps = steps.filter((step) =>
+		sideEffectingStepIds.has(step.id),
+	);
 
-		throw new Error(`Invalid Configuration:\n${message}`);
-	}
+	await runSteps(preSideEffectSteps);
 
-	return result.right;
+	const decodedConfig = decodeConfig();
+	Object.assign(config, decodedConfig);
+
+	await runSteps(sideEffectingSteps);
+
+	return decodedConfig;
 }

--- a/packages/cli/src/steps/project/path.ts
+++ b/packages/cli/src/steps/project/path.ts
@@ -1,4 +1,5 @@
-import { isCancel, text } from "@clack/prompts";
+import { normalize } from "node:path";
+import { isCancel, log, text } from "@clack/prompts";
 import { Either, Schema } from "effect";
 import { ArrayFormatter } from "effect/ParseResult";
 import { cancel } from "../../utils/cancel";
@@ -9,6 +10,15 @@ export const pathSchema = Schema.Trim.pipe(
 	Schema.pattern(/^(\.\/.*|\.)$/, {
 		message: () => "You need to provide a relative path.",
 	}),
+	Schema.filter(
+		(value) => {
+			const normalized = normalize(value);
+			return normalized !== ".." && !normalized.startsWith("..");
+		},
+		{
+			message: () => "You need to provide a path inside the current directory.",
+		},
+	),
 );
 
 const pathStep = defineStep<string>({
@@ -20,6 +30,16 @@ const pathStep = defineStep<string>({
 	dependencies: ["name"],
 
 	shouldRun: () => true,
+
+	validate(value) {
+		const result = Schema.decodeUnknownEither(pathSchema)(value);
+		if (Either.isRight(result)) return;
+
+		const issues = ArrayFormatter.formatErrorSync(result.left);
+		log.error(issues[0]?.message ?? "You need to provide a valid path.");
+
+		process.exit(1);
+	},
 
 	async execute(config, interactive) {
 		const slug = config.slug ?? "my-app";

--- a/packages/cli/tests/orchestrator.test.ts
+++ b/packages/cli/tests/orchestrator.test.ts
@@ -1,6 +1,7 @@
 import { Schema } from "effect";
 import { describe, expect, it, vi } from "vitest";
 import { orchestrate } from "../src/orchestrator";
+import { pathSchema } from "../src/steps/project/path";
 import type { Step } from "../src/steps/types";
 import { SKIP } from "../src/steps/types";
 
@@ -163,7 +164,51 @@ describe("orchestrate", () => {
 		expect(config).not.toHaveProperty("b");
 	});
 
-	it("throws an invalid configuration error when the final decode fails", async () => {
+	it("throws an invalid configuration error before a side-effecting step runs", async () => {
+		const generate = vi.fn(async () => undefined);
+		const steps = [
+			makeStep({
+				id: "path",
+				configKey: "path",
+				schema: pathSchema,
+			}),
+			makeStep({ id: "generate", group: "generate", execute: generate }),
+		];
+
+		await expect(
+			orchestrate(steps, {
+				interactive: false,
+				initialConfig: { path: "./../x" },
+			}),
+		).rejects.toThrow(
+			"Invalid Configuration:\n  path: You need to provide a path inside the current directory.",
+		);
+
+		expect(generate).not.toHaveBeenCalled();
+	});
+
+	it("returns decoded pre-supplied config after side-effecting steps run", async () => {
+		const generate = vi.fn(async () => undefined);
+		const steps = [
+			makeStep({
+				id: "path",
+				configKey: "path",
+				schema: pathSchema,
+			}),
+			makeStep({ id: "generate", group: "generate", execute: generate }),
+		];
+
+		await expect(
+			orchestrate(steps, {
+				interactive: false,
+				initialConfig: { path: "./apps/web" },
+			}),
+		).resolves.toEqual({ path: "./apps/web" });
+
+		expect(generate).toHaveBeenCalledTimes(1);
+	});
+
+	it("throws an invalid configuration error when the decode fails", async () => {
 		const step = makeStep({
 			id: "color",
 			configKey: "color",

--- a/packages/cli/tests/steps-project.test.ts
+++ b/packages/cli/tests/steps-project.test.ts
@@ -1,9 +1,10 @@
+import { Either, Schema } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import catalogsStep from "../src/steps/project/catalogs";
 import linterStep from "../src/steps/project/linter";
 import nameStep from "../src/steps/project/name";
 import packageManagerStep from "../src/steps/project/package-manager";
-import pathStep from "../src/steps/project/path";
+import pathStep, { pathSchema } from "../src/steps/project/path";
 import runtimeStep from "../src/steps/project/runtime";
 import { type PartialConfig, SKIP } from "../src/steps/types";
 
@@ -244,6 +245,35 @@ describe("project steps", () => {
 	});
 
 	describe("path", () => {
+		it("rejects paths that escape the current directory", () => {
+			for (const value of ["./../escape", "./.."]) {
+				const result = Schema.decodeUnknownEither(pathSchema)(value);
+				expect(Either.isLeft(result)).toBe(true);
+			}
+		});
+
+		it("accepts nested paths and the current directory", () => {
+			for (const value of ["./apps/web", "./my-app", "."]) {
+				const result = Schema.decodeUnknownEither(pathSchema)(value);
+				expect(Either.isRight(result)).toBe(true);
+			}
+		});
+
+		it("exits when a supplied path escapes the current directory", () => {
+			const exit = vi.spyOn(process, "exit").mockImplementation((code) => {
+				throw new Error(`exit:${code ?? 0}`);
+			});
+
+			try {
+				expect(() => pathStep.validate?.("./../escape", {})).toThrow("exit:1");
+				expect(promptMocks.logError).toHaveBeenCalledWith(
+					"You need to provide a path inside the current directory.",
+				);
+			} finally {
+				exit.mockRestore();
+			}
+		});
+
 		it("defaults to the slug directory when no path is configured", async () => {
 			await expect(pathStep.execute({ slug: "acme" }, false)).resolves.toBe(
 				"./acme",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR validates CLI config before running project generation side effects. The main changes are:

- Split orchestration into pre-side-effect and side-effect step phases.
- Decode the assembled config before `generate`, `installDeps`, `gitInit`, and `outro` run.
- Reject project paths that normalize outside the current directory.
- Add tests for early invalid-config failure and path traversal rejection.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped and keeps the existing step order while adding validation before generation and post-generation side effects. Tests cover invalid supplied paths, side-effect prevention, and valid supplied config behavior. No blocking correctness or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Generated the runtime validation harness used for validation.
- Captured the service harness log for the validation run, including exit code and before/after evidence for path validation.
- Ran focused tests with pnpm --filter @ryuujs/forge test on orchestrator and steps-project tests, reporting 21 test files and 280 tests passed, exit code 0.

<a href="https://app.greptile.com/trex/runs/15121470/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/orchestrator.ts | Splits orchestration into pre-side-effect validation and side-effect phases, decoding the assembled config before generation/post steps. |
| packages/cli/src/steps/project/path.ts | Tightens project path validation to reject normalized paths escaping the current directory and adds a validate hook for supplied config. |
| packages/cli/tests/orchestrator.test.ts | Adds coverage that invalid config is rejected before generation and that valid supplied config still permits side-effecting steps. |
| packages/cli/tests/steps-project.test.ts | Adds path schema and validate hook tests for directory traversal rejection while preserving valid relative path behavior. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant CLI
participant Orchestrator
participant PreSteps as Pre-side-effect steps
participant Schema as Config schema
participant SideSteps as Side-effecting steps

CLI->>Orchestrator: orchestrate(steps, options)
Orchestrator->>PreSteps: run project/platform/config steps
PreSteps-->>Orchestrator: populated partial config
Orchestrator->>Schema: decode assembled config
alt invalid config
    Schema-->>Orchestrator: validation issues
    Orchestrator-->>CLI: throw Invalid Configuration
else valid config
    Schema-->>Orchestrator: decoded config
    Orchestrator->>SideSteps: run generate/installDeps/gitInit/outro
    SideSteps-->>Orchestrator: side effects complete
    Orchestrator-->>CLI: return decoded config
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant CLI
participant Orchestrator
participant PreSteps as Pre-side-effect steps
participant Schema as Config schema
participant SideSteps as Side-effecting steps

CLI->>Orchestrator: orchestrate(steps, options)
Orchestrator->>PreSteps: run project/platform/config steps
PreSteps-->>Orchestrator: populated partial config
Orchestrator->>Schema: decode assembled config
alt invalid config
    Schema-->>Orchestrator: validation issues
    Orchestrator-->>CLI: throw Invalid Configuration
else valid config
    Schema-->>Orchestrator: decoded config
    Orchestrator->>SideSteps: run generate/installDeps/gitInit/outro
    SideSteps-->>Orchestrator: side effects complete
    Orchestrator-->>CLI: return decoded config
end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): validate config before generat..."](https://github.com/ryuudotgg/forge/commit/11aa23b189cafbca4110b28ef636be5982a1f697) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45699101)</sub>

<!-- /greptile_comment -->