### PR TITLE
fix(core): contain managed paths to project root

### DIFF
--- a/packages/core/src/apply.ts
+++ b/packages/core/src/apply.ts
@@ -60,7 +60,6 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 		const ensureContained = Effect.fn("Apply.ensureContained")(function* (
 			projectRoot: string,
 			relativePath: string,
-			operation: "remove" | "write",
 		) {
 			const rootPath = resolve(projectRoot);
 			const fullPath = resolve(rootPath, relativePath);
@@ -73,9 +72,6 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 					path: relativePath,
 					message: "Path Escapes Project Root",
 				});
-
-			if (operation === "remove" && (yield* fs.exists(fullPath)))
-				return fullPath;
 
 			const realRoot = yield* fs
 				.realPath(rootPath)
@@ -134,11 +130,7 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 
 			const writesToApply: PlannedWrite[] = [];
 			for (const relativePath of plan.removals) {
-				const fullPath = yield* ensureContained(
-					projectRoot,
-					relativePath,
-					"remove",
-				);
+				const fullPath = yield* ensureContained(projectRoot, relativePath);
 
 				const exists = yield* fs.exists(fullPath);
 				if (!exists) continue;
@@ -170,11 +162,7 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 			}
 
 			for (const file of plan.writes) {
-				const fullPath = yield* ensureContained(
-					projectRoot,
-					file.path,
-					"write",
-				);
+				const fullPath = yield* ensureContained(projectRoot, file.path);
 
 				const exists = yield* fs.exists(fullPath);
 				const nextHash = yield* hashContent(file.content);
@@ -236,11 +224,7 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 
 			const removedPaths: string[] = [];
 			for (const relativePath of plan.removals) {
-				const fullPath = yield* ensureContained(
-					projectRoot,
-					relativePath,
-					"remove",
-				);
+				const fullPath = yield* ensureContained(projectRoot, relativePath);
 
 				const exists = yield* fs.exists(fullPath);
 				if (!exists) continue;
@@ -292,11 +276,7 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 			}
 
 			for (const file of writesToApply) {
-				const fullPath = yield* ensureContained(
-					projectRoot,
-					file.path,
-					"write",
-				);
+				const fullPath = yield* ensureContained(projectRoot, file.path);
 
 				const directory = dirname(fullPath);
 

--- a/packages/core/src/apply.ts
+++ b/packages/core/src/apply.ts
@@ -1,5 +1,5 @@
 import { rmdir } from "node:fs/promises";
-import { dirname, join, resolve, sep } from "node:path";
+import { dirname, isAbsolute, resolve, sep } from "node:path";
 import { FileSystem } from "@effect/platform";
 import { Effect } from "effect";
 import { ApplyError } from "./errors";
@@ -57,6 +57,58 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 	effect: Effect.gen(function* () {
 		const fs = yield* FileSystem.FileSystem;
 
+		const ensureContained = Effect.fn("Apply.ensureContained")(function* (
+			projectRoot: string,
+			relativePath: string,
+			operation: "remove" | "write",
+		) {
+			const rootPath = resolve(projectRoot);
+			const fullPath = resolve(rootPath, relativePath);
+
+			if (
+				isAbsolute(relativePath) ||
+				(fullPath !== rootPath && !fullPath.startsWith(`${rootPath}${sep}`))
+			)
+				return yield* new ApplyError({
+					path: relativePath,
+					message: "Path Escapes Project Root",
+				});
+
+			if (operation === "remove" && (yield* fs.exists(fullPath)))
+				return fullPath;
+
+			const realRoot = yield* fs
+				.realPath(rootPath)
+				.pipe(Effect.catchAll(() => Effect.succeed(null)));
+
+			if (realRoot === null) return fullPath;
+
+			let ancestor = fullPath;
+
+			while (ancestor !== rootPath) {
+				const realAncestor = yield* fs
+					.realPath(ancestor)
+					.pipe(Effect.catchAll(() => Effect.succeed(null)));
+
+				if (realAncestor !== null) {
+					if (
+						realAncestor === realRoot ||
+						realAncestor.startsWith(`${realRoot}${sep}`)
+					)
+						return fullPath;
+
+					return yield* new ApplyError({
+						path: relativePath,
+						message: "Path Escapes Project Root",
+					});
+				}
+
+				ancestor = dirname(ancestor);
+			}
+
+			return fullPath;
+		});
+
 		const hashContent = Effect.fn("Apply.hashContent")(function* (
 			content: string,
 		) {
@@ -82,7 +134,12 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 
 			const writesToApply: PlannedWrite[] = [];
 			for (const relativePath of plan.removals) {
-				const fullPath = join(projectRoot, relativePath);
+				const fullPath = yield* ensureContained(
+					projectRoot,
+					relativePath,
+					"remove",
+				);
+
 				const exists = yield* fs.exists(fullPath);
 				if (!exists) continue;
 
@@ -113,7 +170,12 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 			}
 
 			for (const file of plan.writes) {
-				const fullPath = join(projectRoot, file.path);
+				const fullPath = yield* ensureContained(
+					projectRoot,
+					file.path,
+					"write",
+				);
+
 				const exists = yield* fs.exists(fullPath);
 				const nextHash = yield* hashContent(file.content);
 
@@ -174,7 +236,12 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 
 			const removedPaths: string[] = [];
 			for (const relativePath of plan.removals) {
-				const fullPath = join(projectRoot, relativePath);
+				const fullPath = yield* ensureContained(
+					projectRoot,
+					relativePath,
+					"remove",
+				);
+
 				const exists = yield* fs.exists(fullPath);
 				if (!exists) continue;
 
@@ -225,7 +292,12 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 			}
 
 			for (const file of writesToApply) {
-				const fullPath = join(projectRoot, file.path);
+				const fullPath = yield* ensureContained(
+					projectRoot,
+					file.path,
+					"write",
+				);
+
 				const directory = dirname(fullPath);
 
 				yield* fs.makeDirectory(directory, { recursive: true }).pipe(

--- a/packages/core/tests/apply.test.ts
+++ b/packages/core/tests/apply.test.ts
@@ -29,6 +29,157 @@ async function hashContent(content: string) {
 }
 
 describe("apply", () => {
+	it("refuses writes whose paths escape the project root", async () => {
+		await withTempDir("apply-write-escape", async (scratch) => {
+			const projectRoot = join(scratch, "project");
+			const outside = join(scratch, "escape.txt");
+
+			await mkdir(projectRoot, { recursive: true });
+
+			const error = await Effect.runPromise(
+				Effect.flip(
+					Apply.applyPlan(projectRoot, {
+						lockfile: { artifacts: {} },
+						manifest: { config: {}, installs: [], modules: {} },
+						removals: [],
+						writes: [{ content: "escaped\n", path: "../escape.txt" }],
+					}).pipe(Effect.provide(coreLayer)),
+				),
+			);
+
+			expect(error).toMatchObject({
+				_tag: "ApplyError",
+				message: "Path Escapes Project Root",
+				path: "../escape.txt",
+			});
+			expect(await pathExists(outside)).toBe(false);
+		});
+	});
+
+	it("refuses removals whose paths escape the project root", async () => {
+		await withTempDir("apply-remove-escape", async (scratch) => {
+			const projectRoot = join(scratch, "project");
+			const outside = join(scratch, "outside.txt");
+			const content = "managed\n";
+
+			await mkdir(projectRoot, { recursive: true });
+			await writeText(outside, content);
+			await Effect.runPromise(
+				State.writeLockfile(projectRoot, {
+					artifacts: {
+						"project:file:../outside.txt": {
+							definitionIds: ["test"],
+							hash: await hashContent(content),
+							kind: "file",
+							path: "../outside.txt",
+						},
+					},
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			const error = await Effect.runPromise(
+				Effect.flip(
+					Apply.applyPlan(projectRoot, {
+						lockfile: { artifacts: {} },
+						manifest: { config: {}, installs: [], modules: {} },
+						removals: ["../outside.txt"],
+						writes: [],
+					}).pipe(Effect.provide(coreLayer)),
+				),
+			);
+
+			expect(error).toMatchObject({
+				_tag: "ApplyError",
+				message: "Path Escapes Project Root",
+				path: "../outside.txt",
+			});
+			expect(await readFile(outside, "utf-8")).toBe(content);
+		});
+	});
+
+	it("refuses absolute write paths", async () => {
+		await withTempDir("apply-absolute-write", async (scratch) => {
+			const projectRoot = join(scratch, "project");
+			const outside = join(scratch, "absolute.txt");
+
+			await mkdir(projectRoot, { recursive: true });
+
+			const error = await Effect.runPromise(
+				Effect.flip(
+					Apply.applyPlan(projectRoot, {
+						lockfile: { artifacts: {} },
+						manifest: { config: {}, installs: [], modules: {} },
+						removals: [],
+						writes: [{ content: "escaped\n", path: outside }],
+					}).pipe(Effect.provide(coreLayer)),
+				),
+			);
+
+			expect(error).toMatchObject({
+				_tag: "ApplyError",
+				message: "Path Escapes Project Root",
+				path: outside,
+			});
+			expect(await pathExists(outside)).toBe(false);
+		});
+	});
+
+	it("allows nested writes and removals within the project root", async () => {
+		await withTempDir("apply-contained-paths", async (directory) => {
+			const removedPath = "packages/db/src/index.ts";
+			const removedContent = "export const oldValue = true;\n";
+			const writtenPath = "apps/web/app/page.tsx";
+			const writtenContent = "export default function Page() {}\n";
+
+			await writeText(join(directory, removedPath), removedContent);
+			await Effect.runPromise(
+				State.writeLockfile(directory, {
+					artifacts: {
+						[`project:file:${removedPath}`]: {
+							definitionIds: ["test"],
+							hash: await hashContent(removedContent),
+							kind: "file",
+							path: removedPath,
+						},
+					},
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			await Effect.runPromise(
+				Apply.applyPlan(directory, {
+					lockfile: { artifacts: {} },
+					manifest: { config: {}, installs: [], modules: {} },
+					removals: [removedPath],
+					writes: [{ content: writtenContent, path: writtenPath }],
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			expect(await pathExists(join(directory, removedPath))).toBe(false);
+			expect(await readFile(join(directory, writtenPath), "utf-8")).toBe(
+				writtenContent,
+			);
+		});
+	});
+
+	it("creates a missing project root for contained writes", async () => {
+		await withTempDir("apply-create-root", async (scratch) => {
+			const projectRoot = join(scratch, "project");
+			const path = "apps/web/app/page.tsx";
+			const content = "export default function Page() {}\n";
+
+			await Effect.runPromise(
+				Apply.applyPlan(projectRoot, {
+					lockfile: { artifacts: {} },
+					manifest: { config: {}, installs: [], modules: {} },
+					removals: [],
+					writes: [{ content, path }],
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			expect(await readFile(join(projectRoot, path), "utf-8")).toBe(content);
+		});
+	});
+
 	it("refuses to overwrite a modified managed file", async () => {
 		await withTempDir("apply-overwrite", async (directory) => {
 			await writeText(`${directory}/apps/web/app/layout.tsx`, "user-change\n");

--- a/packages/core/tests/apply.test.ts
+++ b/packages/core/tests/apply.test.ts
@@ -587,7 +587,7 @@ describe("apply", () => {
 		});
 	});
 
-	it("does not prune directories that resolve outside the project root", async () => {
+	it("refuses to remove a file that resolves outside the project root", async () => {
 		await withTempDir("apply-prune-escape", async (scratch) => {
 			const projectRoot = join(scratch, "project");
 			const outside = join(scratch, "outside");
@@ -612,17 +612,23 @@ describe("apply", () => {
 				}).pipe(Effect.provide(coreLayer)),
 			);
 
-			await Effect.runPromise(
-				Apply.applyPlan(projectRoot, {
-					lockfile: { artifacts: {} },
-					manifest: { config: {}, installs: [], modules: {} },
-					removals: [removedFile],
-					writes: [],
-				}).pipe(Effect.provide(coreLayer)),
+			const error = await Effect.runPromise(
+				Effect.flip(
+					Apply.applyPlan(projectRoot, {
+						lockfile: { artifacts: {} },
+						manifest: { config: {}, installs: [], modules: {} },
+						removals: [removedFile],
+						writes: [],
+					}).pipe(Effect.provide(coreLayer)),
+				),
 			);
 
-			expect(await pathExists(join(outside, "sub/index.ts"))).toBe(false);
-			expect(await pathExists(join(outside, "sub"))).toBe(true);
+			expect(error).toMatchObject({
+				_tag: "ApplyError",
+				message: "Path Escapes Project Root",
+				path: removedFile,
+			});
+			expect(await pathExists(join(outside, "sub/index.ts"))).toBe(true);
 			expect(await pathExists(join(projectRoot, "packages/link"))).toBe(true);
 		});
 	});


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR contains managed apply paths within the project root. The main changes are:

- Adds path validation for apply-plan removals and writes.
- Rejects absolute paths and parent-directory escapes.
- Adds tests for escaped paths, absolute writes, contained nested paths, and missing project roots.

<h3>Confidence Score: 4/5</h3>

This PR has one contained path-boundary issue to fix before merging.

The main traversal checks are covered, but removals through existing symlinked paths skip realpath validation and can delete files outside the project root.

packages/core/src/apply.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran a focused Vitest repro of the real Apply.applyPlan removal path for a symlink escaping containment; the test showed the outside target existed before and was removed after apply.
- I inspected the repro artifacts for the symlink containment test, including the focused test source and verbose Vitest output, to verify the steps and outcomes.
- I executed the symlink write containment validation using the exact Vitest harness and observed a passing focused test.
- I reviewed the after-log, runtime proof, and the proof-note documenting the path setup and outside-root existence checks, confirming the observed behavior.

<a href="https://app.greptile.com/trex/runs/15125654/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/apply.ts | Adds path containment checks before writes/removals, but existing removal targets return before symlink escape validation. |
| packages/core/tests/apply.test.ts | Adds coverage for traversal and absolute paths, but does not assert that removals through symlinked directories outside the root are rejected. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Apply as Apply.applyPlan
participant Guard as ensureContained
participant FS as FileSystem

Apply->>Guard: validate removal/write path
Guard->>Guard: resolve(projectRoot, relativePath)
alt absolute or lexical escape
    Guard-->>Apply: ApplyError(Path Escapes Project Root)
else contained lexically
    Guard->>FS: realPath(projectRoot / ancestors)
    alt real ancestor outside root
        Guard-->>Apply: ApplyError(Path Escapes Project Root)
    else contained
        Guard-->>Apply: fullPath
        Apply->>FS: remove or write fullPath
    end
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Apply as Apply.applyPlan
participant Guard as ensureContained
participant FS as FileSystem

Apply->>Guard: validate removal/write path
Guard->>Guard: resolve(projectRoot, relativePath)
alt absolute or lexical escape
    Guard-->>Apply: ApplyError(Path Escapes Project Root)
else contained lexically
    Guard->>FS: realPath(projectRoot / ancestors)
    alt real ancestor outside root
        Guard-->>Apply: ApplyError(Path Escapes Project Root)
    else contained
        Guard-->>Apply: fullPath
        Apply->>FS: remove or write fullPath
    end
end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/core/src/apply.ts:77-78
**Remove skips symlink containment**
For removals, this branch returns as soon as `fullPath` exists, so the realpath ancestor check below does not run. When `packages/link/sub/index.ts` is managed and `packages/link` is a symlink outside `projectRoot`, `fs.remove(fullPath)` still deletes the outside file instead of raising `Path Escapes Project Root`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): contain managed paths to proj..."](https://github.com/ryuudotgg/forge/commit/47d37a86bd78348a0e040d83e69b4ef2ebee9834) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45707973)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->