### PR TITLE
fix(core): fail on corrupt manifest

### DIFF
--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -189,11 +189,12 @@ export class State extends Effect.Service<State>()("State", {
 
 		const readManifestOrDefault = Effect.fn("State.readManifestOrDefault")(
 			function* (projectRoot: string) {
-				return yield* readManifest(projectRoot).pipe(
-					Effect.catchTag("StateError", () =>
-						Effect.succeed(defaultManifest()),
-					),
-				);
+				const path = manifestPath(projectRoot);
+				const exists = yield* fs.exists(path);
+
+				if (!exists) return defaultManifest();
+
+				return yield* readManifest(projectRoot);
 			},
 		);
 

--- a/packages/core/tests/state.test.ts
+++ b/packages/core/tests/state.test.ts
@@ -186,7 +186,7 @@ describe("project state", () => {
 		});
 	});
 
-	it("fails to read a corrupt manifest and falls back to the default", async () => {
+	it("fails to read a corrupt manifest", async () => {
 		await withTempDir("manifest-corrupt", async (directory) => {
 			await writeText(join(directory, ".forge/manifest.json"), "{broken");
 
@@ -202,13 +202,19 @@ describe("project state", () => {
 			});
 			expect(error.message).toMatch(/^Manifest Parse Failed: /);
 
-			const fallback = await Effect.runPromise(
-				State.readManifestOrDefault(directory).pipe(
-					Effect.provide(projectLayer),
+			const fallbackError = await Effect.runPromise(
+				Effect.flip(
+					State.readManifestOrDefault(directory).pipe(
+						Effect.provide(projectLayer),
+					),
 				),
 			);
 
-			expect(fallback).toEqual({ config: {}, installs: [], modules: {} });
+			expect(fallbackError).toMatchObject({
+				_tag: "StateError",
+				filePath: join(directory, ".forge/manifest.json"),
+			});
+			expect(fallbackError.message).toMatch(/^Manifest Parse Failed: /);
 		});
 	});
 
@@ -230,6 +236,17 @@ describe("project state", () => {
 			expect(head).toBe("Invalid Manifest");
 			expect(issues.length).toBeGreaterThan(0);
 			for (const issue of issues) expect(issue).toMatch(/^ {2}\S/);
+
+			const fallbackError = await Effect.runPromise(
+				Effect.flip(
+					State.readManifestOrDefault(directory).pipe(
+						Effect.provide(projectLayer),
+					),
+				),
+			);
+
+			expect(fallbackError).toMatchObject({ _tag: "StateError" });
+			expect(fallbackError.message).toMatch(/^Invalid Manifest\n/);
 		});
 	});
 
@@ -277,6 +294,14 @@ describe("project state", () => {
 				_tag: "StateError",
 				message: "Manifest Not Found",
 			});
+
+			const manifest = await Effect.runPromise(
+				State.readManifestOrDefault(directory).pipe(
+					Effect.provide(projectLayer),
+				),
+			);
+
+			expect(manifest).toEqual({ config: {}, installs: [], modules: {} });
 
 			const lockfile = await Effect.runPromise(
 				State.readLockfile(directory).pipe(Effect.provide(projectLayer)),


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes manifest fallback behavior for project state reads. The main changes are:

- `readManifestOrDefault` now returns the default manifest only when `.forge/manifest.json` is missing.
- Corrupt or invalid manifests now surface `StateError` instead of being silently replaced.
- State tests now cover corrupt, invalid, and missing manifest cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is small, focused, and covered by tests for the affected behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused state manifest test suite and confirmed all tests passed (13/13).
- Examined the direct runtime outputs to distinguish missing versus corrupt manifest behavior, noting that a missing manifest returns an empty state and a corrupt manifest raises a StateError with 'Manifest Parse Failed'.
- Reviewed the generated direct-check test harness used for the narrow manifest behavior proof to verify the proof setup is correct.

<a href="https://app.greptile.com/trex/runs/15130680/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/state.ts | Changed `readManifestOrDefault` to default only on an absent manifest while surfacing errors for existing manifests. |
| packages/core/tests/state.test.ts | Updated tests for corrupt, invalid, and missing manifest behavior. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Caller
participant State as State.readManifestOrDefault
participant FS as FileSystem
participant Parser as readManifest/decodeManifest

Caller->>State: readManifestOrDefault(projectRoot)
State->>FS: exists(.forge/manifest.json)
alt manifest missing
    FS-->>State: false
    State-->>Caller: defaultManifest()
else manifest present
    FS-->>State: true
    State->>Parser: readManifest(projectRoot)
    alt valid manifest
        Parser-->>State: Manifest
        State-->>Caller: Manifest
    else corrupt or invalid manifest
        Parser-->>State: StateError
        State-->>Caller: fail(StateError)
    end
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Caller
participant State as State.readManifestOrDefault
participant FS as FileSystem
participant Parser as readManifest/decodeManifest

Caller->>State: readManifestOrDefault(projectRoot)
State->>FS: exists(.forge/manifest.json)
alt manifest missing
    FS-->>State: false
    State-->>Caller: defaultManifest()
else manifest present
    FS-->>State: true
    State->>Parser: readManifest(projectRoot)
    alt valid manifest
        Parser-->>State: Manifest
        State-->>Caller: Manifest
    else corrupt or invalid manifest
        Parser-->>State: StateError
        State-->>Caller: fail(StateError)
    end
end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): fail on corrupt manifest"](https://github.com/ryuudotgg/forge/commit/3f5e594b4e1cd4936b864cc180ac49892447a1ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45718337)</sub>

<!-- /greptile_comment -->