### PR TITLE
fix(cli): strict arg parsing, drop dead flag

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,3 +1,4 @@
+import type { SubcommandDef } from "./commands/registry";
 import type { PartialConfig } from "./steps/types";
 
 interface CLIOption {
@@ -139,11 +140,6 @@ export const options = {
 		configKey: "nativeStyleFramework",
 	},
 
-	"accept-incoming": {
-		type: "boolean",
-		description: "Accept all incoming changes on conflicts.",
-	},
-
 	"no-install": {
 		type: "boolean",
 		description: "Do not install dependencies.",
@@ -158,15 +154,7 @@ export const options = {
 export const sections: CLISection[] = [
 	{
 		title: "Options",
-		keys: [
-			"config",
-			"preset",
-			"accept-incoming",
-			"no-install",
-			"no-git",
-			"help",
-			"version",
-		],
+		keys: ["config", "preset", "no-install", "no-git", "help", "version"],
 	},
 	{
 		title: "Field Overrides",
@@ -209,6 +197,13 @@ export function getParseArgsOptions(): Record<
 	}
 
 	return result;
+}
+
+export function isUnknownCommand(
+	subcommand: string | undefined,
+	command: SubcommandDef | undefined,
+): boolean {
+	return subcommand !== undefined && command === undefined;
 }
 
 export function buildFlagOverrides(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 import { parseArgs } from "node:util";
 import { checkRuntime } from "@ryuujs/core";
 import { version } from "../package.json" with { type: "json" };
-import { getParseArgsOptions } from "./cli";
+import { getParseArgsOptions, isUnknownCommand } from "./cli";
 import { defaultCommand, getSubcommand } from "./commands/registry";
 import { printHelp } from "./utils/help";
 
@@ -11,43 +11,65 @@ if (!runtimeCheck.ok) {
 	process.exit(1);
 }
 
-const { values, positionals } = parseArgs({
-	options: getParseArgsOptions(),
-	allowPositionals: true,
-	strict: false,
-});
+const parsed = (() => {
+	try {
+		return parseArgs({
+			options: getParseArgsOptions(),
+			allowPositionals: true,
+			strict: true,
+		});
+	} catch {
+		console.error(
+			"We don't recognize that option. Run forge --help to see the available flags.",
+		);
 
-if (values.help) {
-	printHelp();
-	process.exit(0);
-}
+		process.exitCode = 1;
+	}
+})();
 
-if (values.version) {
-	console.log(`We're on Forge v${version}`);
-	process.exit(0);
-}
+if (parsed) {
+	const { values, positionals } = parsed;
 
-const subcommand = positionals[0];
-
-try {
-	console.log();
-
-	const cmd = subcommand ? getSubcommand(subcommand) : undefined;
-	if (cmd) {
-		const args = positionals.slice(1);
-		if (cmd.arg && cmd.argRequired && args.length === 0) {
-			console.error(`Usage: forge ${subcommand} ${cmd.arg}`);
-			process.exit(1);
-		}
-
-		await cmd.run(args, values);
-	} else {
-		const [, cmd] = defaultCommand;
-		await cmd.run(positionals, values);
+	if (values.help) {
+		printHelp();
+		process.exit(0);
 	}
 
-	console.log();
-} catch (error) {
-	console.error(error);
-	process.exitCode = 1;
+	if (values.version) {
+		console.log(`We're on Forge v${version}`);
+		process.exit(0);
+	}
+
+	const subcommand = positionals[0];
+	const cmd = subcommand ? getSubcommand(subcommand) : undefined;
+
+	try {
+		if (isUnknownCommand(subcommand, cmd)) {
+			console.error(
+				"We don't recognize that command. Run forge --help to see what forge can do.",
+			);
+
+			process.exitCode = 1;
+		} else {
+			console.log();
+
+			if (cmd) {
+				const args = positionals.slice(1);
+				if (cmd.arg && cmd.argRequired && args.length === 0) {
+					console.error(`Usage: forge ${subcommand} ${cmd.arg}`);
+					process.exit(1);
+				}
+
+				await cmd.run(args, values);
+			} else {
+				const [, defaultCmd] = defaultCommand;
+				await defaultCmd.run(positionals, values);
+			}
+
+			console.log();
+		}
+	} catch (error) {
+		console.error(error);
+		process.exitCode = 1;
+	}
 }

--- a/packages/cli/tests/index.test.ts
+++ b/packages/cli/tests/index.test.ts
@@ -1,0 +1,57 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { isUnknownCommand } from "../src/cli";
+import { getSubcommand } from "../src/commands/registry";
+
+const cliPath = fileURLToPath(new URL("../dist/index.mjs", import.meta.url));
+
+function runCli(args: string[]) {
+	return spawnSync(process.execPath, [cliPath, ...args], { encoding: "utf8" });
+}
+
+describe("CLI argument parsing", () => {
+	it("uses create for a bare invocation and rejects unknown commands", () => {
+		expect(isUnknownCommand(undefined, undefined)).toBe(false);
+		expect(
+			isUnknownCommand("definitely-not-a-command", getSubcommand("bogus")),
+		).toBe(true);
+	});
+
+	it("rejects unknown options with a helpful error", () => {
+		const result = runCli(["--no-such-flag"]);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain(
+			"We don't recognize that option. Run forge --help to see the available flags.",
+		);
+		expect(result.stderr).not.toContain("node:internal");
+	});
+
+	it("rejects unknown commands with a helpful error", () => {
+		const result = runCli(["definitely-not-a-command"]);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain(
+			"We don't recognize that command. Run forge --help to see what forge can do.",
+		);
+	});
+
+	it("accepts help and currently valid flags", () => {
+		const result = runCli([
+			"--config",
+			"forge.config.json",
+			"--preset",
+			"default",
+			"--no-install",
+			"--no-git",
+			"--web",
+			"nextjs",
+			"--help",
+		]);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("--no-install");
+		expect(result.stdout).not.toContain("--accept-incoming");
+	});
+});

--- a/packages/cli/tests/index.test.ts
+++ b/packages/cli/tests/index.test.ts
@@ -1,57 +1,50 @@
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
 import { describe, expect, it } from "vitest";
-import { isUnknownCommand } from "../src/cli";
+import { getParseArgsOptions, isUnknownCommand } from "../src/cli";
 import { getSubcommand } from "../src/commands/registry";
 
-const cliPath = fileURLToPath(new URL("../dist/index.mjs", import.meta.url));
-
-function runCli(args: string[]) {
-	return spawnSync(process.execPath, [cliPath, ...args], { encoding: "utf8" });
+function parse(args: string[]) {
+	return parseArgs({
+		options: getParseArgsOptions(),
+		allowPositionals: true,
+		strict: true,
+		args,
+	});
 }
 
 describe("CLI argument parsing", () => {
-	it("uses create for a bare invocation and rejects unknown commands", () => {
+	it("classifies a bare invocation, known commands, and unknown commands", () => {
 		expect(isUnknownCommand(undefined, undefined)).toBe(false);
+		expect(isUnknownCommand("add", getSubcommand("add"))).toBe(false);
 		expect(
 			isUnknownCommand("definitely-not-a-command", getSubcommand("bogus")),
 		).toBe(true);
 	});
 
-	it("rejects unknown options with a helpful error", () => {
-		const result = runCli(["--no-such-flag"]);
-
-		expect(result.status).toBe(1);
-		expect(result.stderr).toContain(
-			"We don't recognize that option. Run forge --help to see the available flags.",
-		);
-		expect(result.stderr).not.toContain("node:internal");
+	it("rejects unknown options under strict parsing", () => {
+		expect(() => parse(["--no-such-flag"])).toThrow();
 	});
 
-	it("rejects unknown commands with a helpful error", () => {
-		const result = runCli(["definitely-not-a-command"]);
-
-		expect(result.status).toBe(1);
-		expect(result.stderr).toContain(
-			"We don't recognize that command. Run forge --help to see what forge can do.",
-		);
+	it("no longer accepts the removed accept-incoming flag", () => {
+		expect(() => parse(["--accept-incoming"])).toThrow();
 	});
 
-	it("accepts help and currently valid flags", () => {
-		const result = runCli([
-			"--config",
-			"forge.config.json",
-			"--preset",
-			"default",
-			"--no-install",
-			"--no-git",
-			"--web",
-			"nextjs",
-			"--help",
-		]);
+	it("accepts every currently valid flag", () => {
+		expect(() =>
+			parse([
+				"--config",
+				"forge.config.json",
+				"--preset",
+				"default",
+				"--no-install",
+				"--no-git",
+				"--web",
+				"nextjs",
+			]),
+		).not.toThrow();
 
-		expect(result.status).toBe(0);
-		expect(result.stdout).toContain("--no-install");
-		expect(result.stdout).not.toContain("--accept-incoming");
+		const { values } = parse(["--config", "x.json", "--no-install"]);
+		expect(values.config).toBe("x.json");
+		expect(values["no-install"]).toBe(true);
 	});
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens CLI argument parsing and removes an unused flag. The main changes are:

- Enables strict `parseArgs` handling for CLI options.
- Adds friendly errors for unknown options and unknown subcommands.
- Removes `--accept-incoming` from the CLI options and help output.
- Adds tests for argument parsing behavior.

<h3>Confidence Score: 4/5</h3>

Mostly safe, with one contained test workflow issue.

Production CLI changes are localized and straightforward. The added tests can fail in clean environments because they spawn an unbuilt `dist/index.mjs` file.

`packages/cli/tests/index.test.ts`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that the CLI build completes and produces dist files for the strict CLI workflow.
- Observed the CLI runtime behavior for --help, --version, and an unknown option, with exit statuses and messages indicating proper runtime validation.
- Noted that an unexpected positional argument is not treated as a parse error in the update flow but is handled after a metadata check, highlighting a parse-path nuance.
- Reproduced a clean-state CLI dist removal and ran a focused Vitest invocation, which failed with a MODULE\_NOT\_FOUND error for the dist/index.mjs file.
- T-Rex produced proof for a posted P1 finding.

<a href="https://app.greptile.com/trex/runs/15134091/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/cli.ts | Removes the dead `accept-incoming` option and adds a helper for detecting unknown subcommands. |
| packages/cli/src/index.ts | Switches CLI parsing to strict mode and returns friendly errors for invalid options or commands. |
| packages/cli/tests/index.test.ts | Adds CLI argument parsing tests, but the spawned CLI path depends on a prebuilt `dist/index.mjs`. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant CLI as packages/cli/src/index.ts
participant Parser as node:util parseArgs
participant Registry as commands/registry
participant Command as selected command

User->>CLI: forge [flags] [subcommand]
CLI->>Parser: parseArgs(strict: true)
alt unknown option
    Parser-->>CLI: throws
    CLI-->>User: friendly option error + exit 1
else parsed args
    CLI->>Registry: getSubcommand(positionals[0])
    alt unknown subcommand
        CLI-->>User: friendly command error + exit 1
    else known/default command
        CLI->>Command: run(args, values)
        Command-->>CLI: complete
        CLI-->>User: normal output
    end
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant CLI as packages/cli/src/index.ts
participant Parser as node:util parseArgs
participant Registry as commands/registry
participant Command as selected command

User->>CLI: forge [flags] [subcommand]
CLI->>Parser: parseArgs(strict: true)
alt unknown option
    Parser-->>CLI: throws
    CLI-->>User: friendly option error + exit 1
else parsed args
    CLI->>Registry: getSubcommand(positionals[0])
    alt unknown subcommand
        CLI-->>User: friendly command error + exit 1
    else known/default command
        CLI->>Command: run(args, values)
        Command-->>CLI: complete
        CLI-->>User: normal output
    end
end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Known commands ignore unexpected extra positional arguments**

   - **Bug**
     - Strict parsing rejects unknown flags and unknown top-level commands, but it does not reject additional positional arguments after a known command. Running `node packages/cli/dist/index.mjs update definitely-unknown` starts the update flow (`We're reconciling your installed addons and templates...`) and only fails because the current directory lacks Forge metadata. Under strict argument parsing, this unexpected positional argument should fail deterministically before command execution.
   - **Cause**
     - The CLI appears to validate only the first positional token against the command registry. Remaining positional tokens are left for command handlers or ignored, so commands that do not accept extra arguments can still execute with unexpected input.
   - **Fix**
     - After parsing positionals, validate each command's expected arity or accepted positional schema before dispatch. For commands such as `update` that accept no positional arguments, reject any extra tokens with a clear parse error and non-zero exit before running the command handler.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/cli/tests/index.test.ts:7-10
**Build artifact dependency**
`runCli` points at `../dist/index.mjs`, but the package test script is just `vitest run tests` and `dist/index.mjs` is not part of the source tree. In a clean checkout or CI test job that runs tests before `pnpm --filter @ryuujs/forge build`, these new tests spawn a missing file and fail with `MODULE_NOT_FOUND` instead of exercising the CLI.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): strict arg parsing, drop dead ..."](https://github.com/ryuudotgg/forge/commit/b0a518373cf708f5ae326139b348a770566cecdd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45729004)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->