### PR TITLE
fix(core): treat .env as user-owned, seed a real secret

### DIFF
--- a/packages/core/src/apply.ts
+++ b/packages/core/src/apply.ts
@@ -1,5 +1,5 @@
 import { rmdir } from "node:fs/promises";
-import { dirname, isAbsolute, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, resolve, sep } from "node:path";
 import { FileSystem } from "@effect/platform";
 import { Effect } from "effect";
 import { ApplyError } from "./errors";
@@ -50,6 +50,10 @@ function movedModuleArtifactId(
 
 	const relative = write.path.slice(nextRoot.length + 1);
 	return `module:${moduleId}:file:${previousRoot}/${relative}`;
+}
+
+function isUserOwnedEnv(relativePath: string): boolean {
+	return basename(relativePath) === ".env";
 }
 
 export class Apply extends Effect.Service<Apply>()("Apply", {
@@ -131,6 +135,7 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 			const writesToApply: PlannedWrite[] = [];
 			for (const relativePath of plan.removals) {
 				const fullPath = yield* ensureContained(projectRoot, relativePath);
+				if (isUserOwnedEnv(relativePath)) continue;
 
 				const exists = yield* fs.exists(fullPath);
 				if (!exists) continue;
@@ -165,12 +170,12 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 				const fullPath = yield* ensureContained(projectRoot, file.path);
 
 				const exists = yield* fs.exists(fullPath);
-				const nextHash = yield* hashContent(file.content);
-
 				if (!exists) {
 					writesToApply.push(file);
 					continue;
 				}
+
+				if (isUserOwnedEnv(file.path)) continue;
 
 				const currentContent = yield* fs.readFileString(fullPath).pipe(
 					Effect.catchTag(
@@ -182,7 +187,10 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 							}),
 					),
 				);
+
 				const currentHash = yield* hashContent(currentContent);
+				const nextHash = yield* hashContent(file.content);
+
 				if (currentHash === nextHash) continue;
 
 				if (file.artifactId?.endsWith(":file:forge.json")) {
@@ -225,6 +233,7 @@ export class Apply extends Effect.Service<Apply>()("Apply", {
 			const removedPaths: string[] = [];
 			for (const relativePath of plan.removals) {
 				const fullPath = yield* ensureContained(projectRoot, relativePath);
+				if (isUserOwnedEnv(relativePath)) continue;
 
 				const exists = yield* fs.exists(fullPath);
 				if (!exists) continue;

--- a/packages/core/tests/apply.test.ts
+++ b/packages/core/tests/apply.test.ts
@@ -180,6 +180,110 @@ describe("apply", () => {
 		});
 	});
 
+	it("creates a missing .env", async () => {
+		await withTempDir("apply-create-env", async (directory) => {
+			const content = 'AUTH_SECRET="generated"\n';
+
+			await Effect.runPromise(
+				Apply.applyPlan(directory, {
+					lockfile: { artifacts: {} },
+					manifest: { config: {}, installs: [], modules: {} },
+					removals: [],
+					writes: [{ content, path: ".env" }],
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			expect(await readFile(join(directory, ".env"), "utf-8")).toBe(content);
+		});
+	});
+
+	it("leaves an existing .env unchanged", async () => {
+		await withTempDir("apply-user-owned-env", async (directory) => {
+			const userContent = 'AUTH_SECRET="user-secret"\n';
+			await writeText(join(directory, ".env"), userContent);
+
+			await Effect.runPromise(
+				Apply.applyPlan(directory, {
+					lockfile: { artifacts: {} },
+					manifest: { config: {}, installs: [], modules: {} },
+					removals: [],
+					writes: [{ content: 'AUTH_SECRET="generated"\n', path: ".env" }],
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			expect(await readFile(join(directory, ".env"), "utf-8")).toBe(
+				userContent,
+			);
+		});
+	});
+
+	it("does not remove a user-owned .env", async () => {
+		await withTempDir("apply-remove-user-owned-env", async (directory) => {
+			const userContent = 'AUTH_SECRET="user-secret"\n';
+			await writeText(join(directory, ".env"), userContent);
+
+			await Effect.runPromise(
+				State.writeLockfile(directory, {
+					artifacts: {
+						"project:file:.env": {
+							definitionIds: ["better-auth"],
+							hash: await hashContent('AUTH_SECRET="managed"\n'),
+							kind: "file",
+							path: ".env",
+						},
+					},
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			await Effect.runPromise(
+				Apply.applyPlan(directory, {
+					lockfile: { artifacts: {} },
+					manifest: { config: {}, installs: [], modules: {} },
+					removals: [".env"],
+					writes: [],
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			expect(await readFile(join(directory, ".env"), "utf-8")).toBe(
+				userContent,
+			);
+		});
+	});
+
+	it("continues to reconcile .env.example", async () => {
+		await withTempDir("apply-env-example", async (directory) => {
+			const oldContent = 'AUTH_SECRET=""\n';
+			const nextContent = 'AUTH_SECRET="new-template"\n';
+			await writeText(join(directory, ".env.example"), oldContent);
+
+			await Effect.runPromise(
+				State.writeLockfile(directory, {
+					artifacts: {
+						"project:file:.env.example": {
+							definitionIds: ["better-auth"],
+							hash: await hashContent(oldContent),
+							kind: "file",
+							path: ".env.example",
+						},
+					},
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			await Effect.runPromise(
+				Apply.applyPlan(directory, {
+					lockfile: { artifacts: {} },
+					manifest: { config: {}, installs: [], modules: {} },
+					removals: [],
+					writes: [{ content: nextContent, path: ".env.example" }],
+				}).pipe(Effect.provide(coreLayer)),
+			);
+
+			expect(await readFile(join(directory, ".env.example"), "utf-8")).toBe(
+				nextContent,
+			);
+		});
+	});
+
 	it("refuses to overwrite a modified managed file", async () => {
 		await withTempDir("apply-overwrite", async (directory) => {
 			await writeText(`${directory}/apps/web/app/layout.tsx`, "user-change\n");

--- a/packages/generators/src/auth/better-auth/index.ts
+++ b/packages/generators/src/auth/better-auth/index.ts
@@ -18,6 +18,13 @@ import { pmDlx, resolvePackageManager } from "../../pm";
 import type { FirstPartyAddonMetadata } from "../../registry/types";
 import { interpolate, readTemplate } from "../../template";
 
+function generateAuthSecret() {
+	const bytes = crypto.getRandomValues(new Uint8Array(32));
+	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+		"",
+	);
+}
+
 const betterAuthAddon = defineAddon<ForgeConfig, "better-auth", "nextjs">({
 	id: "better-auth",
 	name: "Better Auth",
@@ -128,7 +135,7 @@ const betterAuthAddon = defineAddon<ForgeConfig, "better-auth", "nextjs">({
 				"rootEnv",
 				[
 					`# @use ${secretCommand}`,
-					'AUTH_SECRET="change-me-locally-or-generate-with-the-cli-above"',
+					`AUTH_SECRET="${generateAuthSecret()}"`,
 					'AUTH_COOKIE_DOMAIN="" # empty for localhost, eg. ".example.com"',
 					"",
 					'APP_ORIGIN="http://localhost:3000"',

--- a/packages/generators/tests/addons.test.ts
+++ b/packages/generators/tests/addons.test.ts
@@ -166,9 +166,18 @@ describe("better-auth addon", () => {
 		expect(rootEnv[0]?.lines[0]).toBe(
 			"# @use pnpm dlx @better-auth/cli secret",
 		);
-		expect(rootEnv[0]?.lines).toContain(
-			'AUTH_SECRET="change-me-locally-or-generate-with-the-cli-above"',
+		expect(rootEnv[0]?.lines[1]).toMatch(/^AUTH_SECRET="[0-9a-f]{64}"$/);
+
+		const secondRootEnv = linesSurfaces(
+			contributionsOf(betterAuth, {
+				authentication: "better-auth",
+				orm: "prisma",
+				slug: "acme",
+			}),
+			"rootEnv",
+			"Better Auth",
 		);
+		expect(secondRootEnv[0]?.lines[1]).not.toBe(rootEnv[0]?.lines[1]);
 
 		const rootEnvExample = linesSurfaces(
 			contributions,

--- a/tests/scenarios/src/scenarios/add.test.ts
+++ b/tests/scenarios/src/scenarios/add.test.ts
@@ -1,5 +1,5 @@
 import { readdir, readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	addAddon,
@@ -79,6 +79,8 @@ async function expectMatchingProjects(
 			readFile(join(actualRoot, file), "utf-8"),
 			readFile(join(expectedRoot, file), "utf-8"),
 		]);
+
+		if (basename(file) === ".env") continue;
 
 		expect(actual, file).toBe(expected);
 	}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR protects user-owned environment files and generates a real Better Auth secret. The main changes are:

- Preserve existing `.env` files during writes and removals.
- Create `.env` when it does not exist.
- Generate a random 32-byte Better Auth secret.
- Update unit and scenario tests for user-owned, nondeterministic environment files.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Checked the pre-change environment and logged that AUTH\_SECRET\_HEX64 and SECRET\_ASSERTION\_EXIT\_CODE were redacted and RECONCILIATION\_EXIT\_CODE was 1.
- Checked the post-change state and confirmed AUTH\_SECRET\_LENGTH was added, USER\_VALUE\_INTACT=true, SECRET\_ASSERTION\_EXIT\_CODE remained redacted, and RECONCILIATION\_EXIT\_CODE became 0.
- Ran the final validation to confirm both the source and built distributions contain the changed implementations and that all artifact assertions passed.

<a href="https://app.greptile.com/trex/runs/15428183/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/apply.ts | Treats existing files named `.env` as user-owned while still creating missing files. |
| packages/core/tests/apply.test.ts | Covers `.env` creation, preservation, removal protection, and `.env.example` reconciliation. |
| packages/generators/src/auth/better-auth/index.ts | Generates a cryptographically random 32-byte secret for new Better Auth environments. |
| packages/generators/tests/addons.test.ts | Checks the generated secret format and confirms separate generations differ. |
| tests/scenarios/src/scenarios/add.test.ts | Skips content comparison for nondeterministic `.env` files in scenario fixtures. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): treat .env as user-owned, see..."](https://github.com/ryuudotgg/forge/commit/8491ccdb6456c4f3dac97361b468c8e94e762fe7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46345618)</sub>

<!-- /greptile_comment -->